### PR TITLE
Describe the conventions this repository actually has

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,36 +75,58 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/the-lu
 * Fill in the required template
 * Do not include issue numbers in the PR title
 * Include screenshots and animated GIFs in your pull request whenever possible
-* Follow the JavaScript and CSS styleguides
-* Include adequate tests
+* Follow the TypeScript and Documentation styleguides below
+* Include adequate tests — `npm test` runs against both database engines, and
+  `npm run test:e2e` covers browser-only behaviour
 * Document new code based on the Documentation Styleguide
-* End all files with a newline
+* End all files with a newline, with one deliberate exception: the generated
+  files under `migrations/pg/` are written and identified by `drizzle-kit`, and
+  a trailing newline changes the hash `scripts/migrate.pg.ts` records when it
+  baselines an existing installation. See `docs/adr/0001` before touching them.
 
 ## Styleguides
 
 ### Git Commit Messages
 
-* Use the present tense ("Add feature" not "Added feature")
-* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
-* Limit the first line to 72 characters or less
-* Reference issues and pull requests liberally after the first line
-* Consider starting the commit message with an applicable emoji:
-    * 🎨 `:art:` when improving the format/structure of the code
-    * 🐎 `:racehorse:` when improving performance
-    * 🚱 `:non-potable_water:` when plugging memory leaks
-    * 📝 `:memo:` when writing docs
-    * 🐛 `:bug:` when fixing a bug
-    * 🔥 `:fire:` when removing code or files
-    * 💚 `:green_heart:` when fixing the CI build
-    * ✅ `:white_check_mark:` when adding tests
-    * 🔒 `:lock:` when dealing with security
-    * ⬆️ `:arrow_up:` when upgrading dependencies
-    * ⬇️ `:arrow_down:` when downgrading dependencies
-    * 👕 `:shirt:` when removing linter warnings
+This section describes what the repository already does, so that following it
+and following the history give the same answer.
 
-### JavaScript Styleguide
+**Subject line**
 
-All JavaScript code is linted with [ESLint](https://eslint.org/) and formatted with [Prettier](https://prettier.io/).
+* Limit it to 72 characters, and say what changed rather than which files moved.
+* The imperative mood is the norm — "Add a browser test harness", "Drop
+  DEFAULT_ADMIN_PASSWORD, which nothing reads", "Stop shipping a working
+  database password".
+* A declarative subject naming the resulting behaviour is also used and is
+  equally welcome — "An unparseable density does not clear the stored one",
+  "Ownership reads the role, not the is_admin mirror". Both forms appear
+  throughout the log; neither is a defect, and reviewers should not ask for one
+  to be rewritten as the other.
+* No emoji prefix. Nothing in the history uses one.
+
+**Body**
+
+This is the part that matters most here, and it is the project's most consistent
+habit: nearly every non-trivial commit carries one.
+
+* Explain **why**, not what — the diff already says what. A reader coming back
+  in six months needs the reasoning, the alternative that was rejected, and the
+  constraint that forced the shape.
+* Where a claim is checkable, say how it was checked. Commits that fix a bug
+  routinely quote the failing output, the command that reproduces it, or the
+  test that fails without the change.
+* Wrap at 72 characters.
+* Reference issues and pull requests liberally after the first line.
+
+A commit that only reformats or renames can be a single line. One that changes
+behaviour should not be.
+
+### TypeScript Styleguide
+
+The codebase is TypeScript, and TypeScript is what checks it: `npm run check`
+(Postgres) and `npm run check:sqlite` (SQLite) must both pass, and CI runs both.
+There is no ESLint or Prettier configuration in the repository — an earlier
+version of this file claimed there was.
 
 * Prefer the object spread operator (`{...anotherObj}`) to `Object.assign()`
 * Inline `export`s with expressions whenever possible
@@ -120,17 +142,14 @@ All JavaScript code is linted with [ESLint](https://eslint.org/) and formatted w
   * External packages
   * Internal modules
   * Local modules
-* Place class properties in the following order:
-  * Class methods and properties (methods starting with `static`)
-  * Instance methods and properties
 
 ### Documentation Styleguide
 
 * Use [Markdown](https://daringfireball.net/projects/markdown/) for documentation.
-* Reference methods and classes in markdown with the custom `{}` notation:
-    * Reference classes with `{ClassName}`
-    * Reference instance methods with `{ClassName.methodName}`
-    * Reference class methods with `{ClassName.methodName}`
+* Reference code as a path, optionally with a line — `server/storage.ts:171` —
+  which is what the existing docs and ADRs do and what a reader can click.
+* A decision that shapes the codebase belongs in `docs/adr/`, next to the four
+  already there, rather than only in a pull request description.
 
 ## Additional Notes
 


### PR DESCRIPTION
## Description

Closes #13. `CONTRIBUTING.md` still carried the upstream template it was started from, so several of its rules describe a project this is not. A contributor following the guide and a contributor reading the history get different answers, and the reviewer is the one who pays for that.

### On the commit-message convention — the issue's premise is inverted

The issue reports the history as consistently declarative and the guide as imperative. I measured 119 non-merge subjects before rewriting, and it is the other way round — and neither form is uniform:

| | share |
| --- | --- |
| imperative ("Add…", "Drop…", "Stop shipping…") | **61%** |
| declarative ("An unparseable density does not…") | **14%** |
| ambiguous | 25% |

The eight commits quoted in the issue are a real and well-written run, but they are one contributor's remediation series from #10 rather than the repository norm.

So the fix is **not** to swap one mood for the other — that would make the guide wrong for the majority of the log instead of for a minority of it. Both forms are present, both read well, and the section now says both are accepted, with real examples of each taken from the history and checked to exist verbatim. It also says explicitly that reviewers should not ask for one to be rewritten as the other, since that round trip is the actual cost the issue describes.

**Dropped:** the emoji table. 0 of 119 subjects use one, and it is verbatim upstream template content — the issue is right about that.

**Added:** the body convention, which is this project's strongest habit and was entirely undocumented. 58 of the last 60 non-merge commits carry a body; 55 carry five lines or more. The guide asked for none of it while the project did it consistently, so the one thing a newcomer most needs to imitate was the one thing not written down.

**Kept:** the 72-character subject limit — 115 of 119 subjects observe it.

### Two claims that were false, not merely stale

Both would have cost a contributor real time, and both are the same defect the issue identified, just in neighbouring sections:

- **"All JavaScript code is linted with ESLint and formatted with Prettier."** Neither is a dependency, neither has a config file anywhere in the repo, and `npm run lint` is `tsc --noEmit`. Somebody would have gone looking for a config that does not exist. The section now names what actually gates a change — `npm run check` and `npm run check:sqlite`, both of which CI runs — and is retitled *TypeScript Styleguide*, since that is what the codebase is.
- **The Documentation Styleguide's `{ClassName.methodName}` notation.** It appears nowhere under `docs/`. Replaced with the `path:line` form the existing docs and ADRs actually use, plus a pointer to `docs/adr/` for decisions that shape the codebase.

### Smaller corrections in the same pass

- "Follow the JavaScript and CSS styleguides" pointed at a CSS section that does not exist.
- The PR checklist's "Include adequate tests" now names what running them means here, including the browser suite added in #15.
- **"End all files with a newline"** is the one rule `migrations/pg/` deliberately breaks. #7's ADR recorded the reasoning so nobody would "fix" it later — but a person about to tidy those files is reading `CONTRIBUTING.md`, not ADR-0001. The exception is now recorded in both places.
- The Atom-template class-property ordering rule is dropped; nothing in the codebase observes it.

## A note on authority

Azumi0 offered to open this themselves but held off, saying they did not want to assume the intended wording for a project convention. That caution was right, so this PR deliberately **documents rather than legislates**: every rule in the rewritten sections is one I verified the repository already follows, and where the history is genuinely mixed the guide now says so instead of picking a winner. If you would rather the project standardise on one mood, that is a decision to make on purpose — say which, and it is a one-paragraph change.

## Type of change

- [x] Documentation update

No code changes.

## How Has This Been Tested?

- [x] 119 non-merge commit subjects classified by mood; counts above
- [x] Emoji prefixes: 0 of 119
- [x] Subjects over 72 characters: 4 of 119
- [x] Bodies: 58 of the last 60 non-merge commits, 55 of them ≥ 5 lines
- [x] Every commit subject quoted as an example confirmed to exist verbatim in the log
- [x] ESLint/Prettier absence confirmed against `package.json` and the working tree
- [x] `{ClassName}` notation confirmed absent from `docs/` (the single `{PWD}` hit is a shell variable in a compose path)
- [x] `migrations/pg` newline claim confirmed against `scripts/migrate.pg.ts`, which hashes the file bytes

## Checklist:

- [x] My code follows the style guidelines of this project — including, now, the ones it actually has
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — n/a, documentation only
- [x] Any dependent changes have been merged and published — #15
