### PR TITLE
Make the browser specs survive a cold start and a retry

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -22,6 +22,17 @@ export async function signIn(page: Page, user = DEMO_ADMIN): Promise<void> {
   await page.getByLabel(/password/i).fill(user.password);
   await page.getByRole("button", { name: /login|sign in|anmelden/i }).click();
   await expect(page).not.toHaveURL(/\/login/);
+  // Leaving /login only means the redirect happened; the header renders once the
+  // session query resolves, and everything after this looks for a control inside
+  // it. Waiting here makes that one wait rather than a race repeated at every
+  // call site - which is what timed out in CI on the first spec to run, while
+  // later specs passed against an already-warm app.
+  await expect(settingsButton(page)).toBeVisible({ timeout: 30_000 });
+}
+
+/** The header control every settings interaction starts from. */
+function settingsButton(page: Page) {
+  return page.getByRole("button", { name: /^settings$/i });
 }
 
 /**
@@ -33,7 +44,8 @@ export async function signIn(page: Page, user = DEMO_ADMIN): Promise<void> {
  */
 export async function openMaterialsSettings(page: Page): Promise<void> {
   await page.goto("/");
-  await page.getByRole("button", { name: /^settings$/i }).click();
+  await expect(settingsButton(page)).toBeVisible({ timeout: 30_000 });
+  await settingsButton(page).click();
   await page.getByRole("menuitem", { name: /list management/i }).click();
   await page.getByRole("tab", { name: /^materials$/i }).click();
   await expect(page.getByRole("table")).toBeVisible();

--- a/tests/e2e/materials-attention.spec.ts
+++ b/tests/e2e/materials-attention.spec.ts
@@ -11,9 +11,15 @@ import { signIn, openMaterialsSettings } from "./helpers";
  * notice, and only the last step tells you the round trip actually worked.
  */
 test.describe("the needs-attention prompt", () => {
-  const material = "MoonPLA";
+  // Unique per attempt, because the prompt is a one-way door: the test dismisses
+  // it, which persists. A fixed name makes the CI retry hit an already-dismissed
+  // row and fail for a reason that has nothing to do with the behaviour - which
+  // is exactly what happened the first time this ran on a retry.
+  let material: string;
 
   test.beforeEach(async ({ page }) => {
+    material = `MoonPLA-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+
     await signIn(page);
 
     // Declaring a material that resolves to nothing is what auto-registers it


### PR DESCRIPTION
## Description

The `e2e` job added in #15 failed on #16 — a documentation-only PR that changes nothing but `CONTRIBUTING.md`. That is the worst way for a new suite to introduce itself, and a suite whose own flake reddens unrelated pull requests costs more than it is worth. Two separate defects, both mine, and neither visible on the run that introduced them.

### The cold start

`openMaterialsSettings` clicked the header Settings button straight after `page.goto("/")`. The header only renders once the session query resolves, so the **first** spec to touch the UI raced the application's first paint and timed out after 30s:

```
Error: locator.click: Test timeout of 30000ms exceeded.
Call log:
  - waiting for getByRole('button', { name: /^settings$/i })
```

The density specs ran afterwards against an already-warm app and passed — which is exactly why #15 was green and this only appeared on the next PR. `signIn` now waits for that button before returning, so readiness is asserted once, in one place, rather than raced at every call site.

### The retry

The retry then failed with a **different** error:

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('row').filter({ has: getByText('MoonPLA', ...) }).getByText(/needs attention/i)
Error: element(s) not found
```

The prompt this spec dismisses is a one-way door — the dismissal persists — and every attempt used the same material name. So the CI retry found an already-dismissed row and failed for a reason with nothing to do with the behaviour under test. Worse, it would fail that way *every* time, meaning the retry could never rescue a genuine flake. The name is now unique per attempt.

## How Has This Been Tested?

Both fixes were checked by reproducing the failure rather than reasoning about it. `--repeat-each` runs a spec repeatedly against one database, which is the retry's condition exactly:

| | result |
| --- | --- |
| fixed name, `--repeat-each=2` | **1 failed**, 1 passed — the CI error, reproduced locally |
| unique name, `--repeat-each=3` | **3 passed** |

- [x] `CI=1 npm run test:e2e` — 4 passed (retries enabled, as CI runs it)
- [x] `npm run check` — clean
- [x] The failing assertion in the reproduction is the same one CI reported, not a proxy for it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Test-only. No application code changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective — the fix *is* to the tests; the `--repeat-each` reproduction above is what pins it
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #15
