### PR TITLE
Answer 409 for a duplicate manufacturer or storage location

### DIFF
--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -49,6 +49,19 @@ export function registerSettingsRoutes(app: Express): void {
       parseLine: simpleNameParseLine,
     },
     isInUse: (filament: Filament, item) => filament.manufacturer === item.name,
+    // Exact match, matching manufacturers_name_key. Without it a repeat of a
+    // name already in the list reaches the unique index and comes back as a
+    // bare 500 - every install is seeded with a few, so retyping one in the Add
+    // form is the ordinary case rather than an edge one.
+    //
+    // Exactly what the index compares, so this rejects only what the database
+    // was going to reject anyway. Deliberately not caseless and deliberately
+    // not trimmed: `Prusa` alongside `prusa`, and `" Prusa"` alongside
+    // `"Prusa"`, are both accepted today, and refusing either would be a
+    // behaviour change rather than a fix. The CSV import does compare caselessly
+    // (simpleNameParseLine), so the two paths still disagree - see #11, which is
+    // where that decision belongs.
+    duplicateOf: (item, data) => item.name === data.name,
   });
 
   registerCrudSettingsRoutes<Material, { name: string; density?: string | null; isHygroscopic?: boolean | null }>(app, {
@@ -203,5 +216,8 @@ export function registerSettingsRoutes(app: Express): void {
       parseLine: simpleNameParseLine,
     },
     isInUse: (filament: Filament, item) => filament.storageLocation === item.name,
+    // Exact match, matching storage_locations_name_key - same reasoning as
+    // manufacturers above, including why it is neither caseless nor trimmed.
+    duplicateOf: (item, data) => item.name === data.name,
   });
 }

--- a/tests/routes/settings.test.ts
+++ b/tests/routes/settings.test.ts
@@ -470,3 +470,37 @@ describe("catalog matching agrees across dialects", () => {
     expect(remaining.body).toHaveLength(1);
   });
 });
+
+// Retyping a name the list already holds used to reach the unique index and
+// come back as a bare 500 - `Failed to create manufacturer` - which tells an
+// admin nothing about what went wrong. See #11; `colors` is deliberately not
+// covered here, because it has no unique constraint at all and deciding what
+// makes two colours the same is a product question rather than a bug.
+describe("duplicate creates on the exact-match settings entities", () => {
+  const cases = [
+    { label: "manufacturer", path: "/api/manufacturers", create: (name: string) => storage.createManufacturer({ name }) },
+    { label: "storage location", path: "/api/storage-locations", create: (name: string) => storage.createStorageLocation({ name }) },
+  ];
+
+  for (const { label, path, create } of cases) {
+    it(`answers 409 rather than 500 when a ${label} already has that name`, async () => {
+      await create("Prusa");
+
+      const res = await request(app).post(path).set("Cookie", adminCookie).send({ name: "Prusa" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.message).toMatch(/already exists/i);
+    });
+
+    // The check matches the index exactly, so it rejects only what the database
+    // was going to reject anyway. A case variant is accepted today and stays
+    // accepted - changing that is the open decision in #11, not this fix.
+    it(`still accepts a ${label} that differs only by case`, async () => {
+      await create("Prusa");
+
+      const res = await request(app).post(path).set("Cookie", adminCookie).send({ name: "prusa" });
+
+      expect(res.status).toBe(201);
+    });
+  }
+});


### PR DESCRIPTION
## Description

Part of #11 — the half that is a straight bug fix rather than a product decision.

Retyping a name the list already holds reached the unique index and came back as `500 Failed to create manufacturer`, which tells an admin nothing about what went wrong. Every install ships a handful of these rows, so it is the ordinary case rather than an edge one.

Both entities opt into the `duplicateOf` capability #10 added to the CRUD factory, so this is one line each rather than a new mechanism.

### The comparison is exact, on purpose

Not caseless, not trimmed — precisely what `manufacturers_name_key` and `storage_locations_name_key` compare. So it rejects **only what the database was going to reject anyway**:

| create | before | after |
| --- | --- | --- |
| `Prusa`, then `Prusa` | **500** | **409** |
| `Prusa`, then `prusa` | 201 | 201 (unchanged) |
| `Prusa`, then `" Prusa"` | 201 | 201 (unchanged) |

An earlier draft used `.trim()` on both sides. That would have refused the third row — a behaviour change wearing a bug fix's clothes — so each entity has a test asserting the case variant still returns 201, not just one asserting the duplicate returns 409.

### Why `colors` is not included

The issue lists four remaining entities; it is now **three**, since `diameters` gained `duplicateOf` in #14's remediation (`72e7af3`) after the issue was written. Of those three, `colors` is the one that does not belong in this PR:

- It has **no unique constraint at all**, so a check would be the first thing ever to reject a duplicate colour — not an improvement on a 500.
- It needs a definition of identity the codebase does not have. The CSV import treats a colour as a duplicate only when **name *and* code** match (`settings.ts:141`), while `isInUse` matches on **name *or* code**. Those are different rules and nothing decides between them.

Whether `Red #FF0000` and `Red #CC0000` are one product or two is the product question #11 exists for, so it stays there with that framing.

This also leaves the import and single-create paths still disagreeing about case — `simpleNameParseLine` compares `toLowerCase()` on all of them. Settling that is #11's second option: it needs a migration per table and rejects rows that succeed today.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Non-breaking in both directions: a 500 becomes a 409, and nothing that was accepted stops being accepted.

## How Has This Been Tested?

- [x] `npx vitest run tests/routes/settings.test.ts` — 36 passed
- [x] **Mutation-tested:** removing the two `duplicateOf` lines fails both new cases with `expected 500 to be 409`, so they pin the defect rather than the fix
- [x] `npm run check` — clean
- [x] Four new tests: a 409 case and an "unchanged, still 201" case for each entity

One note on the full local run, for transparency: it showed a single failure in an auth test (`expected 401 to be 200`). I checked it against clean `main`, which also fails — on a *different* auth test each run — and all three affected files pass in isolation (170 passed). It is pre-existing local flakiness under load on this machine, unrelated to this change, and CI has been green on it. Worth knowing about, but not this PR's to fix.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective — and confirmed they fail without it
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #10, #14
