### PR TITLE
Break the createdAt tie when listing catalog requests

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -599,13 +599,16 @@ export class DatabaseStorage implements IStorage {
       .from(catalogRequests)
       .leftJoin(users, eq(catalogRequests.userId, users.id))
       .where(status ? eq(catalogRequests.status, status) : undefined)
-      .orderBy(desc(catalogRequests.createdAt));
+      // Two requests submitted in the same millisecond - the SQLite default
+      // is millisecond epoch - tie on createdAt, and a tie leaves the order to
+      // the engine. The id was handed out in insertion order, so it settles it.
+      .orderBy(desc(catalogRequests.createdAt), desc(catalogRequests.id));
   }
 
   async getCatalogRequestsByUser(userId: number): Promise<CatalogRequest[]> {
     return await db.select().from(catalogRequests)
       .where(eq(catalogRequests.userId, userId))
-      .orderBy(desc(catalogRequests.createdAt));
+      .orderBy(desc(catalogRequests.createdAt), desc(catalogRequests.id));
   }
 
   async getPendingCatalogRequest(id: number): Promise<CatalogRequest | undefined> {

--- a/tests/helpers/app.ts
+++ b/tests/helpers/app.ts
@@ -26,7 +26,17 @@ export async function loginAs(app: Express, username: string, password: string):
   if (response.status !== 200) {
     throw new Error(`login as ${username} failed: ${response.status} ${JSON.stringify(response.body)}`);
   }
-  return response.headers["set-cookie"][0];
+  // Seen once, in a full run under load: a 200 with no Set-Cookie at all,
+  // which the route cannot produce. Rather than a TypeError on [0] that says
+  // nothing, record what actually came back so the next occurrence can be
+  // traced.
+  const cookie = response.headers["set-cookie"]?.[0];
+  if (!cookie) {
+    throw new Error(
+      `login as ${username} answered 200 without a session cookie; headers: ${JSON.stringify(response.headers)} body: ${JSON.stringify(response.body)}`,
+    );
+  }
+  return cookie;
 }
 
 /**

--- a/tests/routes/catalog-requests.test.ts
+++ b/tests/routes/catalog-requests.test.ts
@@ -12,6 +12,8 @@ import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerCatalogRequestRoutes } from "../../server/routes/catalog-requests";
 import { initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
+import { catalogRequests } from "../../shared/schema";
+import { db } from "../helpers/db";
 import { createApp, loginAs, registerAndVerify } from "../helpers/app";
 import { lastMailTo, mailbox } from "../helpers/mailbox";
 
@@ -123,6 +125,22 @@ describe("GET /api/catalog-requests", () => {
   it("returns the newest request first", async () => {
     await submit("material", { name: "PCTG" });
     await submit("material", { name: "TPU95" });
+
+    const response = await request(app).get("/api/catalog-requests").set("Cookie", adminCookie);
+
+    expect(response.body.map((r: { payload: { name: string } }) => r.payload.name)).toEqual(["TPU95", "PCTG"]);
+  });
+
+  // The case above is racy on SQLite: created_at defaults to epoch
+  // milliseconds there, and two submissions inside the same millisecond tie.
+  // This pins what a tie must resolve to - the later id, which is the later
+  // submission - without depending on the clock.
+  it("puts the later submission first when two share a timestamp", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+    await db.insert(catalogRequests).values([
+      { userId: aliceId, entityType: "material", payload: { name: "PCTG" }, createdAt },
+      { userId: aliceId, entityType: "material", payload: { name: "TPU95" }, createdAt },
+    ]);
 
     const response = await request(app).get("/api/catalog-requests").set("Cookie", adminCookie);
 


### PR DESCRIPTION
## Description

The two test files #20 flagged as flaky. One had a real cause; the other did not reproduce, and the helper that hid it now records evidence instead.

### `catalog-requests.test.ts` — a real ordering defect

"returns the newest request first" failed in roughly one run in three on SQLite, with the two requests in submission order. `created_at` defaults to epoch **milliseconds** there, and two submissions through the HTTP stack land in the same millisecond often enough. Equal `createdAt` leaves `ORDER BY` to the engine, which on SQLite means rowid order — oldest first.

Both listings (`listCatalogRequests`, `getCatalogRequestsByUser`) now order by `createdAt` then `id`, both descending. The id is handed out in insertion order, so a tie resolves to the later submission. That is what "newest first" meant. Postgres has microsecond timestamps and rarely ties, but the rule is the same there.

The racy case stays — it is what an admin actually does. A new case inserts two rows with the **same** `createdAt` and asserts the later one comes first:

| | without tiebreak | with tiebreak |
| --- | --- | --- |
| SQLite | fails | passes |
| Postgres | fails | passes |

So it pins the fix without depending on timing.

### `settings.test.ts` — not reproduced, now diagnosable

The failure seen once was `loginAs` dying with `Cannot read properties of undefined (reading '0')`: a `200` with no `Set-Cookie` header at all, on a route that cannot produce that response. The test took 64 ms where every sibling takes 130 ms or more, so the login did not do its bcrypt compare either. I could not reproduce it — six runs of the file alone, six with the two files together, and eight full-suite runs with three or four copies in parallel for load, all green.

The helper now fails with the status, headers and body when the cookie is missing, so the next occurrence says what came back rather than throwing a TypeError. This is the same family as the `expected 401 to be 200` #19 noted on auth tests, and I would rather have evidence than a guess.

`filamentUsageLog` has the same bare `orderBy(desc(createdAt))` at `storage.ts:882`. Nothing asserts its order, so it is left alone here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npx vitest run tests/routes/catalog-requests.test.ts` — 23 passed, both dialects
- [x] **Mutation-tested:** with the tiebreak removed, the new case fails on both dialects with `expected [ 'PCTG', 'TPU95' ] to deeply equal [ 'TPU95', 'PCTG' ]`
- [x] `TEST_DIALECT=sqlite npx vitest run` — 348 passed, 1 skipped, eight times (seven of them under load)
- [x] `npm run check` and `npm run check:sqlite` — clean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective — and confirmed they fail without it
- [x] New and existing unit tests pass locally with my changes