### PR TITLE
Drop the six Header props nothing ever rendered

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -37,23 +37,9 @@ import { useTranslation } from "@/i18n";
 
 interface HeaderProps {
   onAddFilament: () => void;
-  onSearch?: (searchTerm: string) => void;
-  searchTerm?: string;
-  onViewModeChange?: (viewMode: 'grid' | 'table') => void;
-  viewMode?: 'grid' | 'table';
-  onToggleSelectionMode?: () => void;
-  selectionMode?: boolean;
 }
 
-export function Header({
-  onAddFilament,
-  onSearch,
-  searchTerm,
-  onViewModeChange,
-  viewMode,
-  onToggleSelectionMode,
-  selectionMode
-}: HeaderProps) {
+export function Header({ onAddFilament }: HeaderProps) {
   const [themeDialogOpen, setThemeDialogOpen] = useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [settingsDialogTab, setSettingsDialogTab] = useState<string | undefined>(undefined);

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -376,8 +376,6 @@ export default function Home() {
           setSelectedFilament(undefined);
           setShowAddModal(true);
         }}
-        onToggleSelectionMode={handleToggleSelectionMode}
-        selectionMode={selectionMode}
       />
 
       <main className="flex-grow container mx-auto px-4 py-6">


### PR DESCRIPTION
## Description

Closes #22.

`Header` declared seven props, destructured all seven, and read one: `onAddFilament`. The other six — `onSearch`, `searchTerm`, `onViewModeChange`, `viewMode`, `onToggleSelectionMode`, `selectionMode` — never reached the JSX.

The issue asks whether the header lost this UI or never had it. **It never had it.** `6d65bdf` added the six props, the `CheckSquare`/`Square` icons that #20 later removed as unused, and the dropdown menu in one commit, and no commit since has referenced any of the six from the header — `git log -S` on each name finds that one commit alone. Plumbing for a control that was never built.

Each feature already lives elsewhere, which is why nobody missed it:

| feature | where it actually is |
| --- | --- |
| search | filter sidebar, feeding `handleSearchChange` in `home.tsx` |
| grid / table switch | inside `FilamentGrid`, with its own state persisted to localStorage; `home.tsx` has no view-mode state at all |
| selection mode | a button in the `FilamentGrid` toolbar, which `home.tsx` already hands the same handler |

`Header` has one caller, so the two props `home.tsx` passed go with it. Net: 1 insertion, 17 deletions.

One correction to the issue text: #20 did **not** remove these from the destructuring — it removed the two icon imports and `Logo`. `noUnusedLocals` cannot see unused *parameters*, and `noUnusedParameters` stays off on purpose (it flags callback signatures everywhere), so this one needed a hand.

## Type of change

- [x] Code refactoring

## How Has This Been Tested?

- [x] `npm run check` and `npm run check:sqlite` — clean
- [x] `npm run lint` — clean
- [x] `npm run vite:build` — builds

No behaviour to test: every removed binding was unread.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes