### PR TITLE
Answer 404 as JSON for an /api path no route claims

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 This document provides comprehensive documentation for the Filadex API endpoints. The API allows you to manage filaments, materials, colors, manufacturers, and other resources in the Filadex application.
 
+Every path under `/api` that no endpoint below claims answers `404 Not Found` with `{"message": "Not found"}`, for every method. Only paths outside `/api` fall through to the web application.
+
 ## Table of Contents
 
 1. [Authentication](#authentication)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ import { registerCommunityFilamentRoutes } from "./community-filaments";
 import { registerIntegrationRoutes } from "./integrations";
 import { registerSpoolmanCompatRoutes } from "./spoolman-compat";
 import { registerBackupRoutes } from "./backups";
+import { registerApiNotFound } from "./not-found";
 // All routes have been extracted - routes.ts is now empty or contains only legacy code
 // Keeping registerRemainingRoutes import for backward compatibility
 import { registerRemainingRoutes } from "../routes";
@@ -51,6 +52,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Register any remaining routes from routes.ts (should be empty now)
   registerRemainingRoutes(app);
+
+  // Last, so that every /api path no module above claimed is a JSON 404
+  // rather than the SPA shell the catch-all would otherwise serve it.
+  registerApiNotFound(app);
 
   const httpServer = createServer(app);
   return httpServer;

--- a/server/routes/not-found.ts
+++ b/server/routes/not-found.ts
@@ -1,0 +1,15 @@
+import type { Express } from "express";
+
+/**
+ * Answers 404 as JSON for any /api path no route claimed, for every method.
+ *
+ * Mounted after the last route module and before the SPA catch-all. Without it
+ * a mistyped API path fell through to the catch-all and came back as the HTML
+ * shell with a 200, which no client can tell from success without reading the
+ * body, and which the request log records as a success.
+ */
+export function registerApiNotFound(app: Express): void {
+  app.use("/api", (_req, res) => {
+    res.status(404).json({ message: "Not found" });
+  });
+}

--- a/tests/routes/api-not-found.test.ts
+++ b/tests/routes/api-not-found.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Every /api path no route claims is a JSON 404, for every method. Before
+ * registerApiNotFound existed, such a request fell through to the SPA
+ * catch-all and was answered with the HTML shell and a 200 (#25).
+ */
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { registerAuthRoutes } from "../../server/routes/auth";
+import { registerApiNotFound } from "../../server/routes/not-found";
+import { createApp } from "../helpers/app";
+
+const app = createApp(registerAuthRoutes, registerApiNotFound);
+
+describe("an /api path no route claims", () => {
+  it("is a JSON 404 for a GET", async () => {
+    const res = await request(app).get("/api/auth/mee");
+
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body).toEqual({ message: "Not found" });
+  });
+
+  it("is a JSON 404 for a POST too", async () => {
+    const res = await request(app).post("/api/filaments/typo").send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Not found" });
+  });
+
+  it("does not shadow a route that does exist", async () => {
+    const res = await request(app).get("/api/auth/me");
+
+    // 401, not 404: the route answered, and it wanted a session.
+    expect(res.status).toBe(401);
+  });
+
+  it("leaves paths outside /api alone", async () => {
+    const res = await request(app).get("/some-page");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({});
+  });
+});

--- a/tests/server/serve-static.test.ts
+++ b/tests/server/serve-static.test.ts
@@ -6,6 +6,7 @@ import request from "supertest";
 import cookieParser from "cookie-parser";
 import * as resolveLanguageModule from "../../server/utils/resolve-language";
 import { serveStatic } from "../../server/vite";
+import { registerApiNotFound } from "../../server/routes/not-found";
 
 const publicDir = path.resolve(import.meta.dirname, "../../server/public");
 const indexFile = path.resolve(publicDir, "index.html");
@@ -73,6 +74,21 @@ describe("serveStatic", () => {
       .set("Cookie", ["language=pl"])
       .set("If-None-Match", res.headers["etag"]);
     expect(revalidated.status).toBe(304);
+  });
+
+  it("does not serve the shell to an /api path once the API 404 is mounted ahead of it", async () => {
+    const app: Express = express();
+    app.use(cookieParser());
+    registerApiNotFound(app);
+    serveStatic(app);
+
+    const typo = await request(app).get("/api/auth/mee");
+    expect(typo.status).toBe(404);
+    expect(typo.body).toEqual({ message: "Not found" });
+
+    const page = await request(app).get("/some-page");
+    expect(page.status).toBe(200);
+    expect(page.text).toContain("<html lang=");
   });
 
   it("forwards errors to next() when resolveLanguage rejects", async () => {


### PR DESCRIPTION
## Description

Closes #25.

Every route module mounts under `/api`, and after the last of them came the SPA catch-all. So a request to an API path nothing matched — a typo, a removed endpoint, a client built against a newer server — was answered with the HTML shell and a **200**, for every method. No client could tell that from success without reading the body, and the request log recorded it as one.

`registerApiNotFound` mounts `app.use("/api", …)` as the last step of `registerRoutes`, before either catch-all, so development and production answer the same way:

| request | before | after |
| --- | --- | --- |
| `GET /api/auth/mee` | 200 `text/html` | 404 `{"message":"Not found"}` |
| `POST /api/filaments/typo` | 200 `text/html` | 404 `{"message":"Not found"}` |
| `GET /some-page` | 200 shell | 200 shell (unchanged) |

The issue asked whether anything relies on the fall-through. Checked: every `app.get/post/put/patch/delete` in `server/routes` is under `/api`, and no `apiRequest` call in the client targets a path outside it.

Side effect worth having: those requests no longer reach the shell handler, so a browser `GET` to a mistyped API path no longer runs the `<html lang>` session lookup that #24 guards the other cases against — the last case the issue notes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Non-breaking for anything that speaks the API correctly. Anything that was reading a 200 HTML shell as success was already broken.

## How Has This Been Tested?

- [x] `tests/routes/api-not-found.test.ts` — GET and POST answer JSON 404; an existing route still wins (`/api/auth/me` → 401, not 404); a path outside `/api` is left alone
- [x] `tests/server/serve-static.test.ts` — with the handler ahead of the catch-all, `/api/auth/mee` is a JSON 404 while `/some-page` is still the shell
- [x] `TEST_DIALECT=sqlite npx vitest run` — 413 passed, 1 skipped
- [x] `npm run build && npm run test:e2e` — 6 passed
- [x] Built server probed with curl: both typo requests answer 404 JSON, and the request log now reads `GET /api/auth/mee 404 in 1ms :: {"message":"Not found"}`
- [x] `npm run check`, `npm run lint` — clean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
