### PR TITLE
Close the authentication gaps the security audit found

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ PGPORT=5432
 APP_PORT=8080
 LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARN, ERROR
 
+# The address users open Filadex at, e.g. https://filadex.example.com. Links in
+# verification and password-reset emails are built from this and only this -
+# never from the request, whose Host header anyone can forge. With it unset,
+# those emails are not sent and the log says why.
+APP_URL=
+
 # Secret used to sign login sessions (JWT). Set this to a long random string
 # (e.g. `openssl rand -hex 32`) so sessions survive container restarts.
 # If unset, a random secret is generated on each startup and all users are logged out on restart.
@@ -43,5 +49,6 @@ JWT_SECRET=
 # spoof their IP and bypass rate limiting.
 TRUST_PROXY=false
 
-# Admin User Configuration
-ADMIN_PASSWORD=admin
+# There is no variable for the admin password. The first admin is created as
+# admin/admin when no admin account exists, and every route except changing the
+# password is refused until it has been changed.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,14 @@ PORT=8080                     # Port the application will run on
 LOG_LEVEL=INFO                # Logging level (DEBUG, INFO, WARN, ERROR)
 
 # Authentication
-# The first admin is always created as admin/admin and must change the password
-# at first login - there is no variable that sets it.
+# The first admin is created as admin/admin whenever no admin account exists,
+# and every route except changing the password is refused until it has been
+# changed. There is no variable that sets it.
 JWT_SECRET=your_secret_key    # Secret key for JWT token generation
+
+# The address users open Filadex at. Verification and password-reset emails
+# link here and are not sent while it is unset.
+APP_URL=https://filadex.example.com
 
 # Localization
 # Build-time last resort for the UI language (en, de, pl). Reached only when a
@@ -182,7 +187,7 @@ For Docker deployment, you can configure the port in the `docker-compose.yml` fi
 ### Authentication and User Management
 
 1. **First Login**: The system comes with a default admin user (username: `admin`, password: `admin`)
-2. **Password Change**: On first login, you will be required to change the default password
+2. **Password Change**: Until the default password has been changed, the server refuses every other request from that account, and the app takes you to the change-password page
 3. **User Management**: Admin users can access the user management interface by clicking the users icon in the header
 4. **Creating Users**: Admins can create new users, set permissions, and manage existing accounts
 5. **Sharing Filaments**: Users can share their filament collection by clicking the share icon in the header

--- a/client/src/components/settings/settings-email.tsx
+++ b/client/src/components/settings/settings-email.tsx
@@ -19,6 +19,7 @@ interface EmailSettingsResponse {
   fromEmail: string | null;
   fromName: string | null;
   hasPassword: boolean;
+  appUrlConfigured: boolean;
 }
 
 const EMPTY_FORM = {
@@ -91,6 +92,11 @@ export function EmailSettingsCard() {
         <CardDescription>{t("settings.email.description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
+        {data && !data.appUrlConfigured && (
+          <p className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm text-amber-900 dark:text-amber-200">
+            {t("settings.email.appUrlMissing")}
+          </p>
+        )}
         <div className="flex items-center justify-between">
           <Label htmlFor="email-enabled">{t("settings.email.enable")}</Label>
           <Switch

--- a/client/src/i18n/locales/de.ts
+++ b/client/src/i18n/locales/de.ts
@@ -325,6 +325,7 @@ const translations = {
       smtpUser: 'SMTP-Benutzername',
       smtpPassword: 'SMTP-Passwort',
       passwordUnchanged: 'Leer lassen, um das aktuelle Passwort beizubehalten',
+      appUrlMissing: 'APP_URL ist auf dem Server nicht gesetzt, daher werden Bestätigungs- und Passwort-Zurücksetzen-E-Mails nicht versendet. Setze es auf die Adresse, unter der Filadex erreichbar ist, zum Beispiel https://filadex.example.com.',
       smtpSecure: 'TLS verwenden',
       fromEmail: 'Absenderadresse',
       fromName: 'Absendername',

--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -344,6 +344,7 @@ const translations = {
       smtpUser: 'SMTP Username',
       smtpPassword: 'SMTP Password',
       passwordUnchanged: 'Leave blank to keep the current password',
+      appUrlMissing: 'APP_URL is not set on the server, so verification and password reset emails are not sent. Set it to the address users open Filadex at, for example https://filadex.example.com.',
       smtpSecure: 'Use TLS',
       fromEmail: 'From Address',
       fromName: 'From Name',

--- a/client/src/i18n/locales/pl.ts
+++ b/client/src/i18n/locales/pl.ts
@@ -344,6 +344,7 @@ const translations = {
       smtpUser: 'Nazwa użytkownika SMTP',
       smtpPassword: 'Hasło SMTP',
       passwordUnchanged: 'Pozostaw puste, aby zachować bieżące hasło',
+      appUrlMissing: 'APP_URL nie jest ustawiony na serwerze, więc e-maile weryfikacyjne i resetujące hasło nie są wysyłane. Ustaw go na adres, pod którym użytkownicy otwierają Filadex, na przykład https://filadex.example.com.',
       smtpSecure: 'Użyj TLS',
       fromEmail: 'Adres nadawcy',
       fromName: 'Nazwa nadawcy',

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,6 +1,7 @@
 /**
  * API request utility function
  */
+import { redirectIfPasswordChangeRequired } from "./queryClient";
 
 type RequestOptions = {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
@@ -45,6 +46,7 @@ export async function apiRequest<T = any>(
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
+      redirectIfPasswordChangeRequired(response.status, errorData);
 
       // Special handling for 401 errors on auth endpoints or public endpoints
       if (response.status === 401 && (isAuthEndpoint || isPublicEndpoint)) {

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,16 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
+// The server refuses every route but change-password to an account whose
+// password must still be changed, and says so with this code. Send the user
+// there rather than surface a wall of failed requests.
+export function redirectIfPasswordChangeRequired(status: number, body: unknown): void {
+  if (status !== 403 || typeof body !== "object" || body === null) return;
+  if ((body as { code?: string }).code !== "PASSWORD_CHANGE_REQUIRED") return;
+  if (typeof window !== "undefined" && window.location.pathname !== "/change-password") {
+    window.location.assign("/change-password");
+  }
+}
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     try {
@@ -7,6 +18,7 @@ async function throwIfResNotOk(res: Response) {
       // Try to parse the response as JSON
       try {
         const jsonData = JSON.parse(textResponse);
+        redirectIfPasswordChangeRequired(res.status, jsonData);
         // If 'message' or 'detail' is present, return it
         if (jsonData.message || jsonData.detail) {
           // Add status code to the error object for better error handling

--- a/docker-compose.sqlite.template.yml
+++ b/docker-compose.sqlite.template.yml
@@ -20,6 +20,9 @@ services:
       # Set to a long random string (e.g. `openssl rand -hex 32`) so login sessions
       # survive restarts. If unset, a random secret is generated on each startup.
       - JWT_SECRET=${JWT_SECRET:-}
+      # The address users open Filadex at. Emailed links are built from it and
+      # not sent while it is unset - see .env.example.
+      - APP_URL=${APP_URL:-}
       # Only set to "true" if this runs behind a trusted reverse proxy (see .env.example)
       - TRUST_PROXY=${TRUST_PROXY:-false}
     volumes:

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -63,6 +63,9 @@ services:
       # unedited. Left unset, the application generates a random secret per
       # process instead - safe, but sessions do not survive a restart.
       # - JWT_SECRET=
+      # The public address of this install, e.g. https://filadex.your-nas.synology.me.
+      # Verification and password-reset emails link to it and are not sent while unset.
+      # - APP_URL=
 
       # Enable trusted reverse proxy headers.
       # Must be "true" behind DSM Reverse Proxy so Express rate limiters and loggers

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -43,6 +43,9 @@ services:
       # Set to a long random string (e.g. `openssl rand -hex 32`) so login sessions
       # survive restarts. If unset, a random secret is generated on each startup.
       - JWT_SECRET=${JWT_SECRET:-}
+      # The address users open Filadex at. Emailed links are built from it and
+      # not sent while it is unset - see .env.example.
+      - APP_URL=${APP_URL:-}
       # Only set to "true" if this runs behind a trusted reverse proxy (see .env.example)
       - TRUST_PROXY=${TRUST_PROXY:-false}
     depends_on:

--- a/docs/deployment-synology.md
+++ b/docs/deployment-synology.md
@@ -42,7 +42,9 @@ On first startup, [`server/auth.ts`](../server/auth.ts) automatically creates th
 * Password: `admin`
 * Force password change: `forceChangePassword: true`
 
-*(Note: The `DEFAULT_ADMIN_PASSWORD` variable in some compose templates is not read by the authentication code; credentials always initialize to `admin`/`admin`).* Upon your first login, the web interface will immediately redirect you to `/change-password`.
+There is no variable that sets this password. The account is created whenever no account has the admin role, so renaming it does not bring a second one back. Until the password has been changed, the server answers every request from that account except the change itself with `403`, and the web interface takes you to `/change-password`.
+
+**4a. `APP_URL`.** Set this to the address users open Filadex at (for example `https://filadex.your-nas.synology.me`). Verification and password-reset emails link to it, and they are not sent while it is unset - the link must not come from the request, whose `Host` header anyone can forge.
 
 **5. `TRUST_PROXY=true` behind Synology Reverse Proxy.**
 Filadex enforces brute-force rate limiting (e.g., 15 login attempts per 15 minutes in [`server/routes/auth.ts`](../server/routes/auth.ts)). When running behind DSM Reverse Proxy (Nginx on the host), setting `TRUST_PROXY=true` in [`server/index.ts`](../server/index.ts) instructs Express to trust the `X-Forwarded-For` header. Without this, all incoming requests appear to come from the NAS host loopback (`127.0.0.1`), causing rate limits to be shared globally across all users and devices.

--- a/migrations/pg/0007_users_password_changed_at.sql
+++ b/migrations/pg/0007_users_password_changed_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "password_changed_at" timestamp with time zone;

--- a/migrations/pg/meta/0007_snapshot.json
+++ b/migrations/pg/meta/0007_snapshot.json
@@ -1,0 +1,1415 @@
+{
+  "id": "b9ad67cd-8351-4944-9871-8ef2c6beefc7",
+  "prevId": "97e9fae7-6b8d-49ef-943c-fdc323ebb333",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_fkey": {
+          "name": "api_tokens_user_id_fkey",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_key": {
+          "name": "api_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_settings": {
+      "name": "backup_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'02:00'"
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "retention_count": {
+          "name": "retention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "last_backup_at": {
+          "name": "last_backup_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_requests": {
+      "name": "catalog_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_requests_user_id_fkey": {
+          "name": "catalog_requests_user_id_fkey",
+          "tableFrom": "catalog_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "catalog_requests_reviewed_by_fkey": {
+          "name": "catalog_requests_reviewed_by_fkey",
+          "tableFrom": "catalog_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.colors": {
+      "name": "colors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_filament_cache": {
+      "name": "community_filament_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_name": {
+          "name": "color_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "density": {
+          "name": "density",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diameter": {
+          "name": "diameter",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extruder_temp": {
+          "name": "extruder_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bed_temp": {
+          "name": "bed_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_filament_cache_search_idx": {
+          "name": "community_filament_cache_search_idx",
+          "columns": [
+            {
+              "expression": "manufacturer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "color_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_field_definitions": {
+      "name": "custom_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filament'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_definitions_user_id_fkey": {
+          "name": "custom_field_definitions_user_id_fkey",
+          "tableFrom": "custom_field_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diameters": {
+      "name": "diameters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "diameters_value_key": {
+          "name": "diameters_value_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_settings": {
+      "name": "email_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filament_types": {
+      "name": "filament_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_name": {
+          "name": "color_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diameter": {
+          "name": "diameter",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "print_temp": {
+          "name": "print_temp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filament_types_user_id_fkey": {
+          "name": "filament_types_user_id_fkey",
+          "tableFrom": "filament_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filament_usage_log": {
+      "name": "filament_usage_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filament_id": {
+          "name": "filament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta_weight": {
+          "name": "delta_weight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_percentage_after": {
+          "name": "remaining_percentage_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "filament_usage_log_filament_id_idx": {
+          "name": "filament_usage_log_filament_id_idx",
+          "columns": [
+            {
+              "expression": "filament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "filament_usage_log_filament_id_fkey": {
+          "name": "filament_usage_log_filament_id_fkey",
+          "tableFrom": "filament_usage_log",
+          "tableTo": "filaments",
+          "columnsFrom": [
+            "filament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filament_usage_log_user_id_fkey": {
+          "name": "filament_usage_log_user_id_fkey",
+          "tableFrom": "filament_usage_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filaments": {
+      "name": "filaments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filament_type_id": {
+          "name": "filament_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_weight": {
+          "name": "total_weight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_percentage": {
+          "name": "remaining_percentage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spool_type": {
+          "name": "spool_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dryer_count": {
+          "name": "dryer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_drying_date": {
+          "name": "last_drying_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_location": {
+          "name": "storage_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_stock_notified_at": {
+          "name": "low_stock_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drying_reminder_notified_at": {
+          "name": "drying_reminder_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_field_values": {
+          "name": "custom_field_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filaments_user_id_fkey": {
+          "name": "filaments_user_id_fkey",
+          "tableFrom": "filaments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filaments_filament_type_id_fkey": {
+          "name": "filaments_filament_type_id_fkey",
+          "tableFrom": "filaments",
+          "tableTo": "filament_types",
+          "columnsFrom": [
+            "filament_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manufacturers": {
+      "name": "manufacturers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 999
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manufacturers_name_key": {
+          "name": "manufacturers_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.materials": {
+      "name": "materials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 999
+        },
+        "density": {
+          "name": "density",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hygroscopic": {
+          "name": "is_hygroscopic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "attention_dismissed": {
+          "name": "attention_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "materials_global_name_lower_idx": {
+          "name": "materials_global_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"materials\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "materials_user_name_lower_idx": {
+          "name": "materials_user_name_lower_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"user_id\", 0)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"materials\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "materials_user_id_fkey": {
+          "name": "materials_user_id_fkey",
+          "tableFrom": "materials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_locations": {
+      "name": "storage_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 999
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_locations_name_key": {
+          "name": "storage_locations_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sharing": {
+      "name": "user_sharing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sharing_user_id_fkey": {
+          "name": "user_sharing_user_id_fkey",
+          "tableFrom": "user_sharing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_sharing_material_id_fkey": {
+          "name": "user_sharing_material_id_fkey",
+          "tableFrom": "user_sharing",
+          "tableTo": "materials",
+          "columnsFrom": [
+            "material_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_expires": {
+          "name": "email_verification_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_reset_token": {
+          "name": "password_reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_reset_expires": {
+          "name": "password_reset_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "force_change_password": {
+          "name": "force_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "password_changed_at": {
+          "name": "password_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EUR'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'C'"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "low_stock_threshold_percent": {
+          "name": "low_stock_threshold_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 15
+        },
+        "notify_low_stock": {
+          "name": "notify_low_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "notify_drying_reminder": {
+          "name": "notify_drying_reminder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "drying_reminder_days": {
+          "name": "drying_reminder_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "theme_variant": {
+          "name": "theme_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'professional'"
+        },
+        "theme_primary": {
+          "name": "theme_primary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#EA580C'"
+        },
+        "theme_appearance": {
+          "name": "theme_appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dark'"
+        },
+        "theme_radius": {
+          "name": "theme_radius",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.8'"
+        },
+        "username_folded": {
+          "name": "username_folded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_username_folded_idx": {
+          "name": "users_username_folded_idx",
+          "columns": [
+            {
+              "expression": "username_folded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_key": {
+          "name": "users_username_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/pg/meta/_journal.json
+++ b/migrations/pg/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1788613973531,
       "tag": "0006_steep_lucky_pierre",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1788808333286,
+      "tag": "0007_users_password_changed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/sqlite/0001_users_password_changed_at.sql
+++ b/migrations/sqlite/0001_users_password_changed_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `password_changed_at` integer;

--- a/migrations/sqlite/meta/0001_snapshot.json
+++ b/migrations/sqlite/meta/0001_snapshot.json
@@ -1,0 +1,1463 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f30045d4-53c6-4c47-a869-6c56310802a8",
+  "prevId": "68d1b66d-3f66-4e1b-9d97-05fc2f31d4b8",
+  "tables": {
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_token_hash_key": {
+          "name": "api_tokens_token_hash_key",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_fkey": {
+          "name": "api_tokens_user_id_fkey",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_settings": {
+      "name": "backup_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'02:00'"
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retention_count": {
+          "name": "retention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 7
+        },
+        "last_backup_at": {
+          "name": "last_backup_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "catalog_requests": {
+      "name": "catalog_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_requests_user_id_fkey": {
+          "name": "catalog_requests_user_id_fkey",
+          "tableFrom": "catalog_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "catalog_requests_reviewed_by_fkey": {
+          "name": "catalog_requests_reviewed_by_fkey",
+          "tableFrom": "catalog_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "colors": {
+      "name": "colors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_filament_cache": {
+      "name": "community_filament_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_name": {
+          "name": "color_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "density": {
+          "name": "density",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diameter": {
+          "name": "diameter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extruder_temp": {
+          "name": "extruder_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bed_temp": {
+          "name": "bed_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "community_filament_cache_search_idx": {
+          "name": "community_filament_cache_search_idx",
+          "columns": [
+            "manufacturer",
+            "name",
+            "color_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_field_definitions": {
+      "name": "custom_field_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'filament'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_field_definitions_user_id_fkey": {
+          "name": "custom_field_definitions_user_id_fkey",
+          "tableFrom": "custom_field_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diameters": {
+      "name": "diameters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "diameters_value_key": {
+          "name": "diameters_value_key",
+          "columns": [
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filament_types": {
+      "name": "filament_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_name": {
+          "name": "color_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diameter": {
+          "name": "diameter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "print_temp": {
+          "name": "print_temp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filament_types_user_id_fkey": {
+          "name": "filament_types_user_id_fkey",
+          "tableFrom": "filament_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filament_usage_log": {
+      "name": "filament_usage_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filament_id": {
+          "name": "filament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta_weight": {
+          "name": "delta_weight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining_percentage_after": {
+          "name": "remaining_percentage_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "filament_usage_log_filament_id_idx": {
+          "name": "filament_usage_log_filament_id_idx",
+          "columns": [
+            "filament_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "filament_usage_log_filament_id_fkey": {
+          "name": "filament_usage_log_filament_id_fkey",
+          "tableFrom": "filament_usage_log",
+          "tableTo": "filaments",
+          "columnsFrom": [
+            "filament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filament_usage_log_user_id_fkey": {
+          "name": "filament_usage_log_user_id_fkey",
+          "tableFrom": "filament_usage_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filaments": {
+      "name": "filaments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filament_type_id": {
+          "name": "filament_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_weight": {
+          "name": "total_weight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining_percentage": {
+          "name": "remaining_percentage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spool_type": {
+          "name": "spool_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dryer_count": {
+          "name": "dryer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_drying_date": {
+          "name": "last_drying_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_location": {
+          "name": "storage_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "low_stock_notified_at": {
+          "name": "low_stock_notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drying_reminder_notified_at": {
+          "name": "drying_reminder_notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_field_values": {
+          "name": "custom_field_values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filaments_user_id_fkey": {
+          "name": "filaments_user_id_fkey",
+          "tableFrom": "filaments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filaments_filament_type_id_fkey": {
+          "name": "filaments_filament_type_id_fkey",
+          "tableFrom": "filaments",
+          "tableTo": "filament_types",
+          "columnsFrom": [
+            "filament_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "manufacturers": {
+      "name": "manufacturers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 999
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "manufacturers_name_key": {
+          "name": "manufacturers_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "materials": {
+      "name": "materials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 999
+        },
+        "density": {
+          "name": "density",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_hygroscopic": {
+          "name": "is_hygroscopic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "attention_dismissed": {
+          "name": "attention_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "materials_global_name_lower_idx": {
+          "name": "materials_global_name_lower_idx",
+          "columns": [
+            "lower(\"name\")"
+          ],
+          "isUnique": true,
+          "where": "\"materials\".\"user_id\" IS NULL"
+        },
+        "materials_user_name_lower_idx": {
+          "name": "materials_user_name_lower_idx",
+          "columns": [
+            "user_id",
+            "lower(\"name\")"
+          ],
+          "isUnique": true,
+          "where": "\"materials\".\"user_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "materials_user_id_fkey": {
+          "name": "materials_user_id_fkey",
+          "tableFrom": "materials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storage_locations": {
+      "name": "storage_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 999
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "storage_locations_name_key": {
+          "name": "storage_locations_name_key",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_sharing": {
+      "name": "user_sharing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sharing_user_id_fkey": {
+          "name": "user_sharing_user_id_fkey",
+          "tableFrom": "user_sharing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_sharing_material_id_fkey": {
+          "name": "user_sharing_material_id_fkey",
+          "tableFrom": "user_sharing",
+          "tableTo": "materials",
+          "columnsFrom": [
+            "material_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verification_expires": {
+          "name": "email_verification_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_reset_token": {
+          "name": "password_reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_reset_expires": {
+          "name": "password_reset_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "force_change_password": {
+          "name": "force_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "password_changed_at": {
+          "name": "password_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'EUR'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'C'"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "low_stock_threshold_percent": {
+          "name": "low_stock_threshold_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 15
+        },
+        "notify_low_stock": {
+          "name": "notify_low_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_drying_reminder": {
+          "name": "notify_drying_reminder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "drying_reminder_days": {
+          "name": "drying_reminder_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 30
+        },
+        "theme_variant": {
+          "name": "theme_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'professional'"
+        },
+        "theme_primary": {
+          "name": "theme_primary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#EA580C'"
+        },
+        "theme_appearance": {
+          "name": "theme_appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dark'"
+        },
+        "theme_radius": {
+          "name": "theme_radius",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0.8'"
+        },
+        "username_folded": {
+          "name": "username_folded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_key": {
+          "name": "users_username_key",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_folded_idx": {
+          "name": "users_username_folded_idx",
+          "columns": [
+            "username_folded"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "materials_global_name_lower_idx": {
+        "columns": {
+          "lower(\"name\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "materials_user_name_lower_idx": {
+        "columns": {
+          "lower(\"name\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite/meta/_journal.json
+++ b/migrations/sqlite/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1788617841757,
       "tag": "0000_light_catseye",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1788808321351,
+      "tag": "0001_users_password_changed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -21,9 +21,40 @@ function resolveJwtSecret(): string {
 
 const JWT_SECRET = resolveJwtSecret();
 
+// bcrypt work for a login attempt against a username that does not exist, so
+// that "no such user" takes as long as "wrong password" and the two cannot be
+// told apart by timing.
+const NO_SUCH_USER_HASH = bcrypt.hashSync("no-such-user", 10);
+
+export async function verifyPasswordOrBurnTime(plainPassword: string, hashedPassword: string | undefined): Promise<boolean> {
+  if (hashedPassword === undefined) {
+    await bcrypt.compare(plainPassword, NO_SUCH_USER_HASH);
+    return false;
+  }
+  return await bcrypt.compare(plainPassword, hashedPassword);
+}
+
+// Reset and verification tokens are stored hashed, so a read of the users
+// table - a backup, a log, a stray query - does not hand out live tokens. Like
+// API tokens they are 256-bit random values, so a fast digest is the right
+// hash: there is nothing for bcrypt's cost to protect against.
+export function hashSecretToken(plaintext: string): string {
+  return crypto.createHash("sha256").update(plaintext).digest("hex");
+}
+
 // Generate JWT token
 export function generateToken(userId: number): string {
   return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "7d" });
+}
+
+// The session cookie, set the same way wherever a session is issued.
+export function setSessionCookie(res: Response, token: string): void {
+  res.cookie("token", token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
+  });
 }
 
 // Verify a JWT from the token cookie without requiring a full request context.
@@ -49,6 +80,22 @@ export async function hashPassword(password: string): Promise<string> {
   return await bcrypt.hash(password, salt);
 }
 
+// The only routes an account that must still change its password may use.
+// Everything else answers 403 with a code the client turns into a redirect.
+// Without this the flag was a client-side suggestion: a session for
+// admin/admin could drive every route while the password was still admin.
+const ALLOWED_WHILE_PASSWORD_CHANGE_PENDING = new Set([
+  "/api/auth/change-password",
+  "/api/auth/me",
+  "/api/auth/logout",
+]);
+
+function allowedWhilePasswordChangePending(req: Request): boolean {
+  if (ALLOWED_WHILE_PASSWORD_CHANGE_PENDING.has(req.path)) return true;
+  // The change-password page still renders in the user's theme.
+  return req.method === "GET" && req.path === "/api/theme";
+}
+
 // Authentication middleware
 export async function authenticate(req: Request, res: Response, next: NextFunction) {
   const token = req.cookies.token;
@@ -57,32 +104,52 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
     return res.status(401).json({ message: "Authentication required" });
   }
 
+  let decoded: { userId: number; iat?: number };
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as { userId: number };
+    decoded = jwt.verify(token, JWT_SECRET) as { userId: number; iat?: number };
+  } catch {
+    return res.status(401).json({ message: "Invalid or expired token" });
+  }
 
-    if (!decoded || !decoded.userId) {
-      return res.status(401).json({ message: "Invalid token" });
-    }
+  if (!decoded || !decoded.userId) {
+    return res.status(401).json({ message: "Invalid token" });
+  }
 
-    req.userId = decoded.userId;
-
+  try {
     // Get user data and attach to request
     const user = await storage.getUserAuthContext(decoded.userId);
 
-    if (user) {
-      req.user = {
-        id: user.id,
-        username: user.username,
-        isAdmin: user.isAdmin === true,
-        role: user.role
-      };
-    } else {
+    if (!user) {
       return res.status(401).json({ message: "User not found" });
+    }
+
+    // A token issued before the password was last set is refused. `iat` is in
+    // whole seconds, so a token issued in the same second as the change - the
+    // login that follows it - is still accepted.
+    if (user.passwordChangedAt && decoded.iat !== undefined
+        && Math.floor(user.passwordChangedAt.getTime() / 1000) > decoded.iat) {
+      return res.status(401).json({ message: "Session expired because the password was changed" });
+    }
+
+    req.userId = user.id;
+    req.user = {
+      id: user.id,
+      username: user.username,
+      isAdmin: user.isAdmin === true,
+      role: user.role
+    };
+
+    if (user.forceChangePassword && !allowedWhilePasswordChangePending(req)) {
+      return res.status(403).json({
+        message: "You must change your password before continuing",
+        code: "PASSWORD_CHANGE_REQUIRED",
+      });
     }
 
     next();
   } catch (error) {
-    return res.status(401).json({ message: "Invalid or expired token" });
+    logger.error("Authentication error:", error);
+    return res.status(500).json({ message: "Server error" });
   }
 }
 
@@ -147,13 +214,25 @@ export function requireRole(...roles: string[]) {
 // Kept as the admin-only gate used throughout the existing routes.
 export const isAdmin = requireRole("admin");
 
-// Initialize admin user
+// Creates the default admin/admin account when the install has no admin at
+// all. The check is for the role, not the name: it used to look for an account
+// called "admin", so renaming the bootstrap account brought a fresh admin/admin
+// back on the next restart.
 export async function initializeAdminUser() {
   try {
-    // Check if admin user exists
-    const adminExists = await storage.getUserByUsername("admin");
+    if (await storage.countAdmins() > 0) {
+      return;
+    }
 
-    if (!adminExists) {
+    if (await storage.getUserByUsername("admin")) {
+      logger.error(
+        "No account has the admin role, but the username 'admin' is taken, so the default admin cannot be created. " +
+        "Promote an account to admin directly in the database."
+      );
+      return;
+    }
+
+    {
       // Create default admin user
       const hashedPassword = await hashPassword("admin");
       await storage.createUser({
@@ -164,7 +243,7 @@ export async function initializeAdminUser() {
         emailVerified: true,
         forceChangePassword: true
       });
-      logger.info("Default admin user created");
+      logger.warn("Default admin user created with the well-known password 'admin'. Log in and change it now; every other route is refused until you do.");
     }
   } catch (error) {
     logger.error("Error initializing admin user:", error);

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,6 +15,22 @@ const app = express();
 // client spoof its IP via that header and bypass the rate limiters below.
 if (process.env.TRUST_PROXY === "true") {
   app.set("trust proxy", 1);
+} else {
+  // Behind a proxy without the flag every visitor shares the proxy's address,
+  // so the rate limiters treat them as one client: fifteen failed logins from
+  // anyone lock everyone out. Say so, once, the first time a forwarded
+  // request arrives.
+  let warned = false;
+  app.use((req, _res, next) => {
+    if (!warned && req.headers["x-forwarded-for"]) {
+      warned = true;
+      logger.warn(
+        "Requests carry X-Forwarded-For but TRUST_PROXY is not set. Rate limiting is keyed on the proxy's " +
+        "address, so all users share one login limit. Set TRUST_PROXY=true if a trusted reverse proxy is in front."
+      );
+    }
+    next();
+  });
 }
 
 // contentSecurityPolicy is disabled: a correct CSP for the Vite dev server's

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,7 +1,7 @@
-import type { Express, Request } from "express";
+import type { Express } from "express";
 import crypto from "crypto";
-import rateLimit from "express-rate-limit";
 import {
+  type User,
   changePasswordSchema,
   registerSchema,
   forgotPasswordSchema,
@@ -9,10 +9,12 @@ import {
   resendVerificationSchema,
   usernameSchema,
 } from "../../shared/schema";
-import { authenticate, hashPassword, verifyPassword, generateToken } from "../auth";
+import { authenticate, hashPassword, verifyPassword, verifyPasswordOrBurnTime, generateToken, hashSecretToken, setSessionCookie } from "../auth";
 import { storage } from "../storage";
 import { sendMail } from "../utils/mailer";
 import { verificationEmail, passwordResetEmail } from "../utils/email-templates";
+import { getAppUrl } from "../utils/app-url";
+import { publicAuthLimiter, loginLimiter } from "../utils/rate-limits";
 import { resolveAnonymousLanguage } from "../utils/resolve-language";
 import { isSupportedLanguage } from "@shared/languages";
 import { logger as appLogger } from "../utils/logger";
@@ -21,31 +23,39 @@ import { ZodError } from "zod";
 const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1h
 
-// Generic limiter for the public, enumeration-sensitive endpoints (register,
-// forgot-password, resend-verification, check-username).
-const publicAuthLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { message: "Too many requests, please try again later" },
-});
-
-// Slightly tighter limiter for login specifically, to slow down brute force.
-const loginLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 15,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { message: "Too many login attempts, please try again later" },
-});
-
 function generateToken32(): string {
   return crypto.randomBytes(32).toString("hex");
 }
 
-function baseUrl(req: Request): string {
-  return `${req.protocol}://${req.get("host")}`;
+// A link that leaves the browser is built from APP_URL, never from the request:
+// the Host header is whatever the sender says it is, and a forged one turned
+// forgot-password into a genuine email pointing at the attacker's host with the
+// victim's live token. With APP_URL unset the mail is not sent at all, and the
+// log says why, rather than guessing at an origin.
+function emailedLink(path: string, token: string, purpose: string, to: string): string | null {
+  const appUrl = getAppUrl();
+  if (!appUrl) {
+    appLogger.warn(`APP_URL is not set, so the ${purpose} email for ${to} was not sent. Set APP_URL to the address users reach this install at.`);
+    return null;
+  }
+  return `${appUrl}${path}?token=${token}`;
+}
+
+// What the account's owner gets to see of their own row. The hash goes
+// without saying; the pending reset and verification tokens matter too - with
+// them, a stolen session could request a reset and read the token straight
+// back, turning a seven-day cookie into a permanent takeover.
+function sessionUser(user: User) {
+  const {
+    password: _password,
+    passwordResetToken: _resetToken,
+    passwordResetExpires: _resetExpires,
+    emailVerificationToken: _verificationToken,
+    emailVerificationExpires: _verificationExpires,
+    usernameFolded: _folded,
+    ...safe
+  } = user;
+  return safe;
 }
 
 export function registerAuthRoutes(app: Express): void {
@@ -59,9 +69,20 @@ export function registerAuthRoutes(app: Express): void {
         return res.status(400).json({ message: "Username already exists" });
       }
 
+      const created = { message: "Account created. Please check your email to verify your account." };
+
       const existingByEmail = await storage.getUserByEmail(email);
       if (existingByEmail) {
-        return res.status(400).json({ message: "An account with this email already exists" });
+        if (existingByEmail.emailVerified) {
+          // Same answer as for a new address, so the form cannot be used to
+          // find out which emails have accounts. forgot-password and
+          // resend-verification already behave this way.
+          return res.status(201).json(created);
+        }
+        // An unverified row is a claim on the address, not an account: whoever
+        // controls the mailbox gets to complete it. Letting it be replaced means
+        // registering with someone else's email cannot squat on it.
+        await storage.deleteUser(existingByEmail.id);
       }
 
       const hashedPassword = await hashPassword(password);
@@ -78,16 +99,18 @@ export function registerAuthRoutes(app: Express): void {
         role: "user",
         isAdmin: false,
         emailVerified: false,
-        emailVerificationToken: verificationToken,
+        emailVerificationToken: hashSecretToken(verificationToken),
         emailVerificationExpires: new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS),
         forceChangePassword: false,
         language: lang,
       });
 
-      const verifyUrl = `${baseUrl(req)}/verify-email?token=${verificationToken}`;
-      await sendMail({ to: email, ...verificationEmail(lang, verifyUrl) });
+      const verifyUrl = emailedLink("/verify-email", verificationToken, "verification", email);
+      if (verifyUrl) {
+        await sendMail({ to: email, ...verificationEmail(lang, verifyUrl) });
+      }
 
-      res.status(201).json({ message: "Account created. Please check your email to verify your account." });
+      res.status(201).json(created);
     } catch (error) {
       if (error instanceof ZodError) {
         return res.status(400).json({ message: error.errors[0]?.message || "Invalid input" });
@@ -121,7 +144,7 @@ export function registerAuthRoutes(app: Express): void {
         return res.status(400).json({ message: "Invalid verification link" });
       }
 
-      const user = await storage.getUserByEmailVerificationToken(token);
+      const user = await storage.getUserByEmailVerificationToken(hashSecretToken(token));
 
       if (!user || !user.emailVerificationExpires || user.emailVerificationExpires < new Date()) {
         return res.status(400).json({ message: "This verification link is invalid or has expired" });
@@ -147,13 +170,15 @@ export function registerAuthRoutes(app: Express): void {
         const verificationToken = generateToken32();
         await storage.setEmailVerificationToken(
           user.id,
-          verificationToken,
+          hashSecretToken(verificationToken),
           new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS),
         );
 
-        const verifyUrl = `${baseUrl(req)}/verify-email?token=${verificationToken}`;
-        const lang = isSupportedLanguage(user.language) ? user.language : resolveAnonymousLanguage(req);
-        await sendMail({ to: email, ...verificationEmail(lang, verifyUrl) });
+        const verifyUrl = emailedLink("/verify-email", verificationToken, "verification", email);
+        if (verifyUrl) {
+          const lang = isSupportedLanguage(user.language) ? user.language : resolveAnonymousLanguage(req);
+          await sendMail({ to: email, ...verificationEmail(lang, verifyUrl) });
+        }
       }
 
       res.json(genericResponse);
@@ -178,13 +203,15 @@ export function registerAuthRoutes(app: Express): void {
         const resetToken = generateToken32();
         await storage.setPasswordResetToken(
           user.id,
-          resetToken,
+          hashSecretToken(resetToken),
           new Date(Date.now() + RESET_TOKEN_TTL_MS),
         );
 
-        const resetUrl = `${baseUrl(req)}/reset-password?token=${resetToken}`;
-        const lang = isSupportedLanguage(user.language) ? user.language : resolveAnonymousLanguage(req);
-        await sendMail({ to: email, ...passwordResetEmail(lang, resetUrl) });
+        const resetUrl = emailedLink("/reset-password", resetToken, "password reset", email);
+        if (resetUrl) {
+          const lang = isSupportedLanguage(user.language) ? user.language : resolveAnonymousLanguage(req);
+          await sendMail({ to: email, ...passwordResetEmail(lang, resetUrl) });
+        }
       }
 
       res.json(genericResponse);
@@ -202,7 +229,7 @@ export function registerAuthRoutes(app: Express): void {
     try {
       const { token, newPassword } = resetPasswordSchema.parse(req.body);
 
-      const user = await storage.getUserByPasswordResetToken(token);
+      const user = await storage.getUserByPasswordResetToken(hashSecretToken(token));
 
       if (!user || !user.passwordResetExpires || user.passwordResetExpires < new Date()) {
         return res.status(400).json({ message: "This reset link is invalid or has expired" });
@@ -224,13 +251,18 @@ export function registerAuthRoutes(app: Express): void {
   app.post("/api/auth/login", loginLimiter, async (req, res) => {
     try {
       const { username, password } = req.body;
+      if (typeof username !== "string" || typeof password !== "string") {
+        return res.status(401).json({ message: "Invalid credentials" });
+      }
 
       // Matched case-insensitively, the same way registration and admin user
       // creation check for a duplicate: if "ALICE" cannot be registered while
       // "alice" exists, then "ALICE" has to be a way to log in as "alice".
       const user = await storage.getUserByUsername(username);
 
-      if (!user || !(await verifyPassword(password, user.password))) {
+      // The compare runs whether or not the account exists, so the two
+      // failures take the same time.
+      if (!(await verifyPasswordOrBurnTime(password, user?.password)) || !user) {
         return res.status(401).json({ message: "Invalid credentials" });
       }
 
@@ -241,22 +273,10 @@ export function registerAuthRoutes(app: Express): void {
       // Update last login
       await storage.recordLogin(user.id);
 
-      // Generate token
-      const token = generateToken(user.id);
-
-      // Set cookie
-      res.cookie("token", token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
-      });
-
-      // Return user info (without password)
-      const { password: _, ...userWithoutPassword } = user;
+      setSessionCookie(res, generateToken(user.id));
 
       res.json({
-        user: userWithoutPassword,
+        user: sessionUser(user),
         forceChangePassword: user.forceChangePassword
       });
     } catch (error) {
@@ -280,8 +300,7 @@ export function registerAuthRoutes(app: Express): void {
         return res.status(404).json({ message: "User not found" });
       }
 
-      const { password, ...userWithoutPassword } = user;
-      res.json(userWithoutPassword);
+      res.json(sessionUser(user));
     } catch (error) {
       appLogger.error("Get user error:", error);
       res.status(500).json({ message: "Server error" });
@@ -289,7 +308,7 @@ export function registerAuthRoutes(app: Express): void {
   });
 
   // Change password
-  app.post("/api/auth/change-password", authenticate, async (req, res) => {
+  app.post("/api/auth/change-password", authenticate, loginLimiter, async (req, res) => {
     try {
       const result = changePasswordSchema.safeParse(req.body);
 
@@ -306,6 +325,12 @@ export function registerAuthRoutes(app: Express): void {
       }
 
       await storage.changePassword(req.userId, await hashPassword(newPassword));
+
+      // The change invalidates every session issued before it - including, a
+      // second or more after logging in, the one making this request. Hand
+      // that session a fresh cookie so the user carries on; the others stay
+      // locked out, which is the point.
+      setSessionCookie(res, generateToken(req.userId));
 
       res.json({ message: "Password updated successfully" });
     } catch (error) {

--- a/server/routes/email-settings.ts
+++ b/server/routes/email-settings.ts
@@ -6,6 +6,7 @@ import { sendMail, getEmailSettings } from "../utils/mailer";
 import { logger as appLogger } from "../utils/logger";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
+import { getAppUrl } from "../utils/app-url";
 
 export function registerEmailSettingsRoutes(app: Express): void {
   // Get current email settings (admin only). Never returns the SMTP password.
@@ -16,7 +17,9 @@ export function registerEmailSettingsRoutes(app: Express): void {
         return res.status(404).json({ message: "Email settings not found" });
       }
       const { smtpPassword, ...safeSettings } = settings;
-      res.json({ ...safeSettings, hasPassword: !!smtpPassword });
+      // Verification and reset mails carry a link, and the link needs APP_URL;
+      // the settings screen warns when it is missing.
+      res.json({ ...safeSettings, hasPassword: !!smtpPassword, appUrlConfigured: getAppUrl() !== null });
     } catch (error) {
       appLogger.error("Error fetching email settings:", error);
       res.status(500).json({ message: "Failed to fetch email settings" });

--- a/server/routes/integrations.ts
+++ b/server/routes/integrations.ts
@@ -6,6 +6,7 @@ import { authenticate, requireApiToken, generateApiToken } from "../auth";
 import { insertApiTokenSchema, printerUsageEventSchema } from "@shared/schema";
 import { logger as appLogger } from "../utils/logger";
 import { validateId } from "../utils/validation";
+import { sensitiveActionLimiter } from "../utils/rate-limits";
 
 /**
  * Phase A of the printer integration (see IMPLEMENTATION_PLAN.md #5): a
@@ -25,7 +26,7 @@ export function registerIntegrationRoutes(app: Express): void {
     }
   });
 
-  app.post("/api/api-tokens", authenticate, async (req, res) => {
+  app.post("/api/api-tokens", authenticate, sensitiveActionLimiter, async (req, res) => {
     try {
       const { label } = insertApiTokenSchema.parse(req.body);
       const { plaintext, hash } = generateApiToken();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -32,6 +32,8 @@ export type AuthContext = {
   username: string;
   isAdmin: boolean | null;
   role: string;
+  forceChangePassword: boolean | null;
+  passwordChangedAt: Date | null;
 };
 
 /**
@@ -414,6 +416,8 @@ export class DatabaseStorage implements IStorage {
       username: users.username,
       isAdmin: users.isAdmin,
       role: users.role,
+      forceChangePassword: users.forceChangePassword,
+      passwordChangedAt: users.passwordChangedAt,
     }).from(users).where(eq(users.id, id));
     return user || undefined;
   }
@@ -471,15 +475,22 @@ export class DatabaseStorage implements IStorage {
         passwordResetToken: null,
         passwordResetExpires: null,
         forceChangePassword: false,
+        passwordChangedAt: new Date(),
       })
       .where(eq(users.id, userId));
   }
 
-  // Unlike resetPassword this leaves any pending reset token alone, which is
-  // the behaviour the change-password endpoint has always had.
+  // Setting a new password also retires any reset link still out there for the
+  // old one, and stamps the moment so sessions issued before it are refused.
   async changePassword(userId: number, hashedPassword: string): Promise<void> {
     await db.update(users)
-      .set({ password: hashedPassword, forceChangePassword: false })
+      .set({
+        password: hashedPassword,
+        forceChangePassword: false,
+        passwordResetToken: null,
+        passwordResetExpires: null,
+        passwordChangedAt: new Date(),
+      })
       .where(eq(users.id, userId));
   }
 
@@ -511,9 +522,18 @@ export class DatabaseStorage implements IStorage {
 
     // A rename has to carry the folded form with it, or the account keeps
     // answering to its old name and the unique index guards the wrong value.
-    const columns = changes.username === undefined
-      ? changes
+    const columns: Partial<typeof users.$inferInsert> = changes.username === undefined
+      ? { ...changes }
       : { ...changes, usernameFolded: foldUsername(changes.username) };
+
+    // An admin setting a password is a password change like any other: it
+    // retires a pending reset link and invalidates the sessions that came
+    // before it.
+    if (changes.password !== undefined) {
+      columns.passwordResetToken = null;
+      columns.passwordResetExpires = null;
+      columns.passwordChangedAt = new Date();
+    }
 
     const [updated] = await db.update(users).set(columns).where(eq(users.id, id)).returning();
     return updated || undefined;

--- a/server/utils/app-url.ts
+++ b/server/utils/app-url.ts
@@ -1,0 +1,33 @@
+import { logger } from "./logger";
+
+/**
+ * The address this install is reached at, for links that leave the browser.
+ *
+ * Emailed links used to be built from the request's Host header. Nothing
+ * validates that header, so a forged request to forgot-password produced a
+ * genuine Filadex email whose link pointed at the attacker's host and carried
+ * the victim's live reset token. The only safe origin for such a link is one
+ * the operator configured, which is APP_URL.
+ *
+ * Returns null when unset or unusable; callers then decline to send the
+ * email rather than guess.
+ */
+export function getAppUrl(): string | null {
+  const raw = process.env.APP_URL?.trim();
+  if (!raw) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    logger.warn(`APP_URL is not a valid URL: ${raw}`);
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    logger.warn(`APP_URL must start with http:// or https://: ${raw}`);
+    return null;
+  }
+  // origin + path without a trailing slash, so `${appUrl}/reset-password` is
+  // right whether the operator wrote the slash or not.
+  return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+}

--- a/server/utils/rate-limits.ts
+++ b/server/utils/rate-limits.ts
@@ -1,0 +1,34 @@
+import rateLimit from "express-rate-limit";
+
+// Per-IP limiters, shared by the routes that need them. All key on req.ip,
+// which is the proxy's address unless TRUST_PROXY is set - see server/index.ts.
+
+// Public, enumeration-sensitive endpoints: register, forgot-password,
+// resend-verification, check-username.
+export const publicAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many requests, please try again later" },
+});
+
+// Anything that verifies a password: login, and change-password, which with a
+// stolen session would otherwise be an unthrottled oracle for the current one.
+export const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 15,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many login attempts, please try again later" },
+});
+
+// Authenticated actions that mint credentials or do expensive work per call:
+// API token creation, backups, cache refresh, test mail.
+export const sensitiveActionLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many requests, please try again later" },
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -18,6 +18,10 @@ export const users = table("users", {
   passwordResetToken: t.text("password_reset_token"),
   passwordResetExpires: t.timestamp("password_reset_expires"),
   forceChangePassword: t.bool("force_change_password").default(true),
+  // When the password was last set, by the user, a reset link or an admin.
+  // Sessions issued before this moment are refused (server/auth.ts), which is
+  // what makes changing the password a way to lock a stolen cookie out.
+  passwordChangedAt: t.timestamptz("password_changed_at"),
   language: t.text("language").default("en"),
   currency: t.text("currency").default("EUR"),
   temperatureUnit: t.text("temperature_unit").default("C"),

--- a/tests/helpers/app.ts
+++ b/tests/helpers/app.ts
@@ -2,6 +2,8 @@ import express, { type Express } from "express";
 import cookieParser from "cookie-parser";
 import request from "supertest";
 import { lastMailTo, tokenFromMail } from "./mailbox";
+import { initializeAdminUser } from "../../server/auth";
+import { storage } from "../../server/storage";
 
 /**
  * The seam these tests work at: a real express app with the real route
@@ -55,4 +57,17 @@ export async function registerAndVerify(
   await request(app).get("/api/auth/verify-email").query({ token }).expect(200);
 
   return loginAs(app, user.username, user.password);
+}
+
+/**
+ * The default admin/admin account, ready to use. initializeAdminUser creates it
+ * with forceChangePassword set, and the server refuses every route but
+ * change-password to such an account - so a test that wants an admin to drive
+ * the API has to clear the flag first, the way a real first login would.
+ */
+export async function bootstrapAdmin(): Promise<void> {
+  await initializeAdminUser();
+  const admin = await storage.getUserByUsername("admin");
+  if (!admin) throw new Error("initializeAdminUser did not create the admin account");
+  await storage.updateUser(admin.id, { forceChangePassword: false });
 }

--- a/tests/routes/auth.test.ts
+++ b/tests/routes/auth.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Express } from "express";
 import { registerAuthRoutes } from "../../server/routes/auth";
-import { hashPassword } from "../../server/auth";
+import { hashPassword, hashSecretToken } from "../../server/auth";
 import { storage } from "../../server/storage";
 import { createApp, loginAs, registerAndVerify } from "../helpers/app";
 import { lastMailTo, mailbox, tokenFromMail } from "../helpers/mailbox";
@@ -138,15 +138,68 @@ describe("POST /api/auth/register", () => {
     expect(response.body.message).toBe("Username already exists");
   });
 
-  it("rejects an email that already exists, ignoring case", async () => {
-    await request(app).post("/api/auth/register").send(alice).expect(201);
+  it("answers the same way for an email that already has a verified account, and creates nothing", async () => {
+    await registerAndVerify(app, alice);
+    mailbox.length = 0;
 
     const response = await request(app)
       .post("/api/auth/register")
       .send({ ...alice, username: "someone-else", email: "ALICE@EXAMPLE.COM" });
 
-    expect(response.status).toBe(400);
-    expect(response.body.message).toBe("An account with this email already exists");
+    // Saying "already exists" here told anyone which addresses have accounts;
+    // forgot-password and resend-verification never did.
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Account created. Please check your email to verify your account.");
+    expect(await storage.getUserByUsername("someone-else")).toBeUndefined();
+    expect(mailbox).toEqual([]);
+  });
+
+  it("lets a new registration replace an unverified claim on the same email", async () => {
+    // Someone registers with an address they do not control...
+    await request(app).post("/api/auth/register").send({ ...alice, username: "squatter" }).expect(201);
+
+    // ...and the address's owner registers later. They, not the squatter, get
+    // the verification mail, and the squatter's row is gone.
+    await request(app).post("/api/auth/register").send(alice).expect(201);
+    const token = tokenFromMail(lastMailTo(alice.email));
+    await request(app).get("/api/auth/verify-email").query({ token }).expect(200);
+
+    expect(await storage.getUserByUsername("squatter")).toBeUndefined();
+    await expect(loginAs(app, alice.username, alice.password)).resolves.toBeTruthy();
+  });
+
+  it("stores the verification token hashed, so the row does not hold the link", async () => {
+    await request(app).post("/api/auth/register").send(alice).expect(201);
+    const token = tokenFromMail(lastMailTo(alice.email))!;
+
+    const row = await storage.getUserByUsername(alice.username);
+    expect(row?.emailVerificationToken).not.toBe(token);
+    expect(row?.emailVerificationToken).toBe(hashSecretToken(token));
+  });
+
+  it("builds the emailed link from APP_URL, not from the request's Host header", async () => {
+    await request(app)
+      .post("/api/auth/register")
+      .set("Host", "evil.example")
+      .set("X-Forwarded-Host", "evil.example")
+      .send(alice)
+      .expect(201);
+
+    const link = lastMailTo(alice.email)?.html.match(/https?:\/\/[^"'\s]+/)?.[0];
+    expect(link).toMatch(/^http:\/\/filadex\.test\/verify-email\?token=/);
+  });
+
+  it("sends no mail at all when APP_URL is unset, rather than guessing an origin", async () => {
+    vi.stubEnv("APP_URL", "");
+    try {
+      await request(app).post("/api/auth/register").send(alice).expect(201);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(mailbox).toEqual([]);
+    // The account exists; a resend once APP_URL is set will deliver the link.
+    expect(await storage.getUserByUsername(alice.username)).toBeDefined();
   });
 
   it("stores the username with the capitalisation it was given", async () => {
@@ -540,6 +593,97 @@ describe("POST /api/auth/reset-password", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.message).toBe(message);
+  });
+});
+
+describe("the reset token at rest", () => {
+  it("is stored hashed, and still completes the reset", async () => {
+    await registerAndVerify(app, alice);
+    await request(app).post("/api/auth/forgot-password").send({ email: alice.email }).expect(200);
+    const token = tokenFromMail(lastMailTo(alice.email))!;
+
+    const row = await storage.getUserByUsername(alice.username);
+    expect(row?.passwordResetToken).toBe(hashSecretToken(token));
+
+    await request(app).post("/api/auth/reset-password").send({ token, newPassword: "after-reset-pw" }).expect(200);
+    await expect(loginAs(app, alice.username, "after-reset-pw")).resolves.toBeTruthy();
+  });
+
+  it("is never shown to the account itself", async () => {
+    const cookie = await registerAndVerify(app, alice);
+    await request(app).post("/api/auth/forgot-password").send({ email: alice.email }).expect(200);
+
+    // With the token in /me, a stolen session could request a reset, read the
+    // token back and set a new password without knowing the current one.
+    const me = await request(app).get("/api/auth/me").set("Cookie", cookie);
+    expect(me.body).not.toHaveProperty("passwordResetToken");
+    expect(me.body).not.toHaveProperty("passwordResetExpires");
+    expect(me.body).not.toHaveProperty("emailVerificationToken");
+    expect(me.body).not.toHaveProperty("usernameFolded");
+
+    const login = await request(app).post("/api/auth/login").send({ username: alice.username, password: alice.password });
+    expect(login.body.user).not.toHaveProperty("passwordResetToken");
+    expect(login.body.user).not.toHaveProperty("emailVerificationToken");
+  });
+
+  it("is retired when the password is changed the ordinary way", async () => {
+    const cookie = await registerAndVerify(app, alice);
+    await request(app).post("/api/auth/forgot-password").send({ email: alice.email }).expect(200);
+    const token = tokenFromMail(lastMailTo(alice.email))!;
+
+    await request(app)
+      .post("/api/auth/change-password")
+      .set("Cookie", cookie)
+      .send({ currentPassword: alice.password, newPassword: "changed-by-hand" })
+      .expect(200);
+
+    const response = await request(app).post("/api/auth/reset-password").send({ token, newPassword: "via-old-link" });
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("a session issued before the password was set", () => {
+  async function twoSecondsLater(body: () => Promise<void>) {
+    // The token's iat is in whole seconds; moving the clock on makes "before"
+    // unambiguous, the way it is for any real reset.
+    await atTime(new Date(Date.now() + 2_000), body);
+  }
+
+  it("is refused after a reset through the emailed link", async () => {
+    const cookie = await registerAndVerify(app, alice);
+    await request(app).post("/api/auth/forgot-password").send({ email: alice.email }).expect(200);
+    const token = tokenFromMail(lastMailTo(alice.email))!;
+
+    await twoSecondsLater(async () => {
+      await request(app).post("/api/auth/reset-password").send({ token, newPassword: "after-reset-pw" }).expect(200);
+
+      const response = await request(app).get("/api/auth/me").set("Cookie", cookie);
+      expect(response.status).toBe(401);
+      expect(response.body.message).toBe("Session expired because the password was changed");
+
+      // The login that follows the reset gets a fresh session.
+      const fresh = await loginAs(app, alice.username, "after-reset-pw");
+      await request(app).get("/api/auth/me").set("Cookie", fresh).expect(200);
+    });
+  });
+
+  it("is refused after the user changes it themselves, while the changing session gets a fresh cookie", async () => {
+    const stolen = await registerAndVerify(app, alice);
+    const own = await loginAs(app, alice.username, alice.password);
+
+    await twoSecondsLater(async () => {
+      const changed = await request(app)
+        .post("/api/auth/change-password")
+        .set("Cookie", own)
+        .send({ currentPassword: alice.password, newPassword: "locked-out-now" }) // ggignore: throwaway test credential
+        .expect(200);
+
+      await request(app).get("/api/auth/me").set("Cookie", stolen).expect(401);
+      // The old cookie of the changing session is just as dead...
+      await request(app).get("/api/auth/me").set("Cookie", own).expect(401);
+      // ...but the response carried a replacement.
+      await request(app).get("/api/auth/me").set("Cookie", changed.headers["set-cookie"][0]).expect(200);
+    });
   });
 });
 

--- a/tests/routes/backups.test.ts
+++ b/tests/routes/backups.test.ts
@@ -5,9 +5,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerBackupRoutes } from "../../server/routes/backups";
-import { initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 import { useTempBackupDir } from "../helpers/backup-dir";
 
 let app: Express;
@@ -18,7 +17,7 @@ const backupDir = useTempBackupDir();
 
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerBackupRoutes);
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
   userCookie = await registerAndVerify(app, {
     username: "bob",

--- a/tests/routes/catalog-requests.test.ts
+++ b/tests/routes/catalog-requests.test.ts
@@ -10,11 +10,10 @@ import request from "supertest";
 import type { Express } from "express";
 import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerCatalogRequestRoutes } from "../../server/routes/catalog-requests";
-import { initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
 import { catalogRequests } from "../../shared/schema";
 import { db } from "../helpers/db";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 import { lastMailTo, mailbox } from "../helpers/mailbox";
 
 let app: Express;
@@ -28,7 +27,7 @@ const alice = { username: "alice", email: "alice@example.com", password: "correc
 
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerCatalogRequestRoutes);
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
   aliceCookie = await registerAndVerify(app, alice);
   aliceId = (await request(app).get("/api/auth/me").set("Cookie", aliceCookie)).body.id;

--- a/tests/routes/community-filaments.test.ts
+++ b/tests/routes/community-filaments.test.ts
@@ -12,14 +12,13 @@ import request from "supertest";
 import type { Express } from "express";
 import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerCommunityFilamentRoutes } from "../../server/routes/community-filaments";
-import { initializeAdminUser } from "../../server/auth";
 import {
   refreshCommunityFilamentCache,
   searchCommunityFilaments,
 } from "../../server/utils/spoolmandb-sync";
 import { db } from "../helpers/db";
 import { communityFilamentCache } from "../../shared/schema";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
 let app: Express;
 let adminCookie: string;
@@ -27,7 +26,7 @@ let userCookie: string;
 
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerCommunityFilamentRoutes);
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
   userCookie = await registerAndVerify(app, {
     username: "alice",

--- a/tests/routes/email-settings.test.ts
+++ b/tests/routes/email-settings.test.ts
@@ -10,10 +10,9 @@ import request from "supertest";
 import type { Express } from "express";
 import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerEmailSettingsRoutes } from "../../server/routes/email-settings";
-import { initializeAdminUser } from "../../server/auth";
 import { db } from "../helpers/db";
 import { emailSettings } from "../../shared/schema";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
 // This route reads the settings through the mailer, which tests/setup.ts
 // replaces wholesale. Keep the real getEmailSettings - it is part of what is
@@ -36,7 +35,7 @@ let userCookie: string;
 
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerEmailSettingsRoutes);
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
   userCookie = await registerAndVerify(app, {
     username: "alice",

--- a/tests/routes/settings.test.ts
+++ b/tests/routes/settings.test.ts
@@ -13,11 +13,10 @@ import { eq } from "drizzle-orm";
 import type { Express } from "express";
 import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerSettingsRoutes } from "../../server/routes/settings";
-import { initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
 import { db } from "../helpers/db";
 import { materials, users } from "../../shared/schema";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
 let app: Express;
 let adminCookie: string;
@@ -41,7 +40,7 @@ const allMaterialRows = () => db.select().from(materials);
 
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerSettingsRoutes);
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
 });
 

--- a/tests/routes/users.test.ts
+++ b/tests/routes/users.test.ts
@@ -13,7 +13,7 @@ import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerUserRoutes } from "../../server/routes/users";
 import { hashPassword, initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
-import { createApp, loginAs, registerAndVerify } from "../helpers/app";
+import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
 let app: Express;
 let adminCookie: string;
@@ -25,7 +25,7 @@ const alice = { username: "alice", email: "alice@example.com", password: "correc
 beforeEach(async () => {
   app = createApp(registerAuthRoutes, registerUserRoutes);
   // The only way an installation gets its first admin; password is hard-coded.
-  await initializeAdminUser();
+  await bootstrapAdmin();
   adminCookie = await loginAs(app, "admin", "admin");
 });
 
@@ -62,10 +62,90 @@ describe("the default admin bootstrap", () => {
       .send({ username: "Admin" })
       .expect(200);
 
-    await initializeAdminUser();
+    await bootstrapAdmin();
 
     const after = await request(app).get("/api/users").set("Cookie", adminCookie);
     expect(after.body.map((user: { username: string }) => user.username)).toEqual(["Admin"]);
+  });
+});
+
+describe("an account that must still change its password", () => {
+  // The flag used to be enforced only by a redirect in the login page, so a
+  // session for admin/admin could drive every route while the password was
+  // still admin.
+  it("is refused every route but the password change, then admitted", async () => {
+    await createUserAsAdmin({ username: "bob", password: "bobs-password" });
+    const cookie = await loginAs(app, "bob", "bobs-password");
+
+    const refused = await request(app).post("/api/users/language").set("Cookie", cookie).send({ language: "de" });
+    expect(refused.status).toBe(403);
+    expect(refused.body).toEqual({
+      message: "You must change your password before continuing",
+      code: "PASSWORD_CHANGE_REQUIRED",
+    });
+
+    // What the change-password page itself needs still works.
+    await request(app).get("/api/auth/me").set("Cookie", cookie).expect(200);
+
+    const changed = await request(app)
+      .post("/api/auth/change-password")
+      .set("Cookie", cookie)
+      .send({ currentPassword: "bobs-password", newPassword: "bobs-own-password" })
+      .expect(200);
+
+    // The change invalidates the sessions issued before it, this one included,
+    // and answers with a fresh cookie so the page can carry straight on.
+    const fresh = changed.headers["set-cookie"][0];
+    expect(fresh).toMatch(/^token=/);
+    await request(app).post("/api/users/language").set("Cookie", fresh).send({ language: "de" }).expect(200);
+  });
+});
+
+describe("initializeAdminUser", () => {
+  it("does not bring admin/admin back once the bootstrap account has been renamed", async () => {
+    const admins = await request(app).get("/api/users").set("Cookie", adminCookie);
+    const admin = admins.body.find((user: { role: string }) => user.role === "admin");
+
+    await request(app).put(`/api/users/${admin.id}`).set("Cookie", adminCookie).send({ username: "paul" }).expect(200);
+
+    // What every startup runs. It used to look for an account *named* admin.
+    await initializeAdminUser();
+
+    const after = await request(app).get("/api/users").set("Cookie", adminCookie);
+    expect(after.body.map((user: { username: string }) => user.username)).toEqual(["paul"]);
+    await request(app).post("/api/auth/login").send({ username: "admin", password: "admin" }).expect(401);
+  });
+
+  it("still creates the default admin on an install with no admin at all", async () => {
+    const admins = await request(app).get("/api/users").set("Cookie", adminCookie);
+    const admin = admins.body.find((user: { role: string }) => user.role === "admin");
+    await storage.deleteUser(admin.id);
+
+    await initializeAdminUser();
+
+    const created = await storage.getUserByUsername("admin");
+    expect(created).toMatchObject({ role: "admin", forceChangePassword: true });
+  });
+});
+
+describe("a session issued before an admin set a new password", () => {
+  it("is refused", async () => {
+    const bob = await createUserAsAdmin({ username: "bob", password: "bobs-password", forceChangePassword: false });
+    const cookie = await loginAs(app, "bob", "bobs-password");
+
+    // Two seconds on, so the token's whole-second iat is unambiguously earlier.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 2_000);
+    try {
+      // Throwaway test-database credential, not a real login anywhere (hence the ggignore tag).
+      await request(app).put(`/api/users/${bob.id}`).set("Cookie", adminCookie).send({ password: "set-by-admin-1" }).expect(200); // ggignore
+
+      const response = await request(app).get("/api/auth/me").set("Cookie", cookie);
+      expect(response.status).toBe(401);
+      expect(response.body.message).toBe("Session expired because the password was changed");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -285,6 +365,7 @@ describe("POST /api/users", () => {
       username: "root",
       password: "roots-password",
       isAdmin: true,
+      forceChangePassword: false,
     });
 
     expect(created).toMatchObject({ isAdmin: true, role: "admin" });
@@ -419,7 +500,7 @@ describe("PUT /api/users/:id", () => {
   });
 
   it("promotes a user to admin", async () => {
-    const bob = await createUserAsAdmin({ username: "bob", password: "bobs-password" });
+    const bob = await createUserAsAdmin({ username: "bob", password: "bobs-password", forceChangePassword: false });
 
     const response = await request(app)
       .put(`/api/users/${bob.id}`)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,9 @@ export default defineConfig({
     include: ["tests/**/*.test.{ts,tsx}"],
     // A fixed secret keeps issued JWTs valid for the whole run and silences the
     // random-secret warning server/auth.ts logs on import.
-    env: { JWT_SECRET: "filadex-test-secret", NODE_ENV: "test" },
+    // APP_URL because emailed links are built from it and not sent without it;
+    // the tests read tokens out of those links.
+    env: { JWT_SECRET: "filadex-test-secret", NODE_ENV: "test", APP_URL: "http://filadex.test" },
     globalSetup: ["tests/global-setup.ts"],
     setupFiles: ["tests/setup.ts"],
     // Every test file talks to the same database server, and each rebuilds the


### PR DESCRIPTION
## Description

First of three PRs from the security audit of `main` at `cbec119`. This one is the authentication layer: the three high findings and the two medium ones that chain off a stolen cookie. Every item here was reproduced against a built instance before it was fixed, and each fix has a test that fails without it.

### High

| finding | fix |
| --- | --- |
| **Renaming the bootstrap admin brought `admin/admin` back on restart.** `initializeAdminUser` looked for an account *named* admin. | Runs only when no account has the admin role. If the name is taken but no admin exists, it logs how to recover instead of creating one. |
| **The forced password change was a client redirect.** No server code read `forceChangePassword`; a session for `admin/admin` could drive every route. | `authenticate` answers 403 `{ code: "PASSWORD_CHANGE_REQUIRED" }` on every route except change-password, `/me`, logout and the theme read. Both client request helpers turn that code into the redirect. |
| **Emailed links were built from the `Host` header.** A forged forgot-password produced a genuine mail linking to the attacker's host with the victim's live token. | New `APP_URL` setting; every emailed link comes from it. With it unset the mail is not sent and the log says why; the email settings screen shows the same warning. Added to `.env.example`, all three compose templates, README and the Synology guide. |

### Medium

| finding | fix |
| --- | --- |
| **Sessions survived password reset, change, admin-set and logout** for seven days. | `users.password_changed_at` (migration for both dialects). Every path that sets a password stamps it; `authenticate` refuses a token issued before it. `iat` is whole seconds, so the login that follows a change in the same second still works. Logout still cannot revoke a single token without a blocklist; a password change now can. |
| **`/me` and login returned the pending reset and verification tokens**, in plain text. With a stolen session: request a reset, read the token, set a new password. | Self endpoints project the row (no hash, no tokens, no folded name). Tokens are stored as SHA-256 hashes and compared by hash. Pending links from before this upgrade are invalid; they live one hour and one day, so nobody waits long. |

### Low, folded in because they live in the same files

- Registration answers the same way for an address with a verified account (it said "already exists"), and an unverified registration can be replaced by a later one for the same email, so nobody can squat on an address they do not own.
- Login for an unknown username still pays for a bcrypt compare, so it takes as long as a wrong password. Non-string credentials are a 401, not a 500.
- `change-password` retires a pending reset link and shares the login limiter. API token creation is limited. Limiters move to `server/utils/rate-limits.ts` so the next PR can reuse them.
- The server warns once when `X-Forwarded-For` arrives without `TRUST_PROXY`, since every visitor then shares one login limit.
- `.env.example` no longer offers `ADMIN_PASSWORD`, which nothing reads. README and the Synology guide now describe what the server actually enforces.

### Tests

`tests/helpers/app.ts` gains `bootstrapAdmin()`: `initializeAdminUser` plus clearing the flag, the way a first login would. Six test files that drove the API as the bootstrap admin use it. Two existing tests were updated for the changed behaviour (registration no longer discloses emails; admin-created admins in the role tests opt out of the forced change, since that is not what they test). New tests pin every fix: the forced-change 403 and the path through it, the bootstrap not recreating a renamed admin and still creating one when none exists, hashed tokens at rest, the link built from `APP_URL` under a hostile `Host`, no mail without `APP_URL`, tokens absent from `/me` and login, a session refused after reset, after self-service change from another session, and after an admin-set password, and the reset link retired by a change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change — two, both deliberate and documented: an install without `APP_URL` no longer sends verification or reset mail until it is set; and an account with the forced-change flag can no longer use the API until the password is changed.

## How Has This Been Tested?

- [x] `TEST_DIALECT=sqlite npx vitest run` — 426 passed, 1 skipped
- [x] `npx vitest run tests/routes/{auth,users,settings}.test.ts` on Postgres — 186 passed
- [x] `npm run db:check-drift` — checked-in migrations describe the schema on both dialects
- [x] `npm run check`, `npm run lint` — clean
- [x] `npm run build && npm run test:e2e` — 6 passed

One full SQLite run had a single failure in a `beforeEach` registration answering 200 instead of 201, in `community-filaments.test.ts`; three reruns of the file passed. Same register → verify → login helper family as before.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
