### PR TITLE
Tighten the API's handling of what comes in and what goes out

### DIFF
--- a/client/src/components/change-password-modal.tsx
+++ b/client/src/components/change-password-modal.tsx
@@ -41,10 +41,6 @@ export function ChangePasswordModal({ open, onOpenChange }: { open: boolean; onO
 
   const changePasswordMutation = useMutation({
     mutationFn: async (data: PasswordFormValues) => {
-      console.log("Sending change password request:", {
-        currentPassword: data.currentPassword,
-        newPassword: data.newPassword
-      });
 
       return apiRequest("/api/auth/change-password", {
         method: "POST",

--- a/client/src/lib/auth.tsx
+++ b/client/src/lib/auth.tsx
@@ -41,7 +41,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const login = (userData: User) => {
-    console.log("Setting user in auth context:", userData);
     setUser(userData);
     localStorage.setItem("isAuthenticated", "true");
   };

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -44,11 +44,7 @@ export async function apiRequest<T = any>(
   options?: RequestInit
 ): Promise<T> {
   try {
-    // Only log API requests for non-authentication endpoints to reduce console noise
     const isAuthEndpoint = url.includes('/api/auth/');
-    if (!isAuthEndpoint) {
-      console.log(`Making API request to: ${url}`, options);
-    }
 
     const res = await fetch(url, {
       ...options,
@@ -74,14 +70,7 @@ export async function apiRequest<T = any>(
       return undefined as T;
     }
 
-    const data = await res.json();
-
-    // Only log responses for non-authentication endpoints
-    if (!isAuthEndpoint) {
-      console.log(`API response from ${url}:`, data);
-    }
-
-    return data;
+    return await res.json();
   } catch (error) {
     // Only log errors for non-authentication endpoints or if it's not a 401 error
     const isAuthEndpoint = url.includes('/api/auth/');
@@ -106,11 +95,6 @@ export const getQueryFn: <T>(options: {
       const url = queryKey[0] as string;
       const isAuthEndpoint = url.includes('/api/auth/');
 
-      // Only log queries for non-authentication endpoints
-      if (!isAuthEndpoint) {
-        console.log(`Making query to: ${url}`);
-      }
-
       const res = await fetch(url, {
         credentials: "include",
       });
@@ -128,14 +112,7 @@ export const getQueryFn: <T>(options: {
       }
 
       await throwIfResNotOk(res);
-      const data = await res.json();
-
-      // Only log responses for non-authentication endpoints
-      if (!isAuthEndpoint) {
-        console.log(`Query response from ${url}:`, data);
-      }
-
-      return data;
+      return await res.json();
     } catch (error) {
       const url = queryKey[0] as string;
       const isAuthEndpoint = url.includes('/api/auth/');

--- a/client/src/pages/change-password.tsx
+++ b/client/src/pages/change-password.tsx
@@ -43,10 +43,6 @@ export default function ChangePasswordPage() {
 
   const changePasswordMutation = useMutation({
     mutationFn: async (data: ChangePasswordFormValues) => {
-      console.log("Sending change password request:", {
-        currentPassword: data.currentPassword,
-        newPassword: data.newPassword
-      });
 
       return apiRequest("/api/auth/change-password", {
         method: "POST",

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -48,7 +48,6 @@ export default function LoginPage() {
       });
     },
     onSuccess: (data) => {
-      console.log("Login successful:", data);
       login(data.user);
 
       // Add a small delay to ensure the auth state is updated

--- a/docs/API.md
+++ b/docs/API.md
@@ -1352,7 +1352,7 @@ Lets a print server (Klipper/Moonraker, or a custom integration) report filament
 
 ### API Tokens
 
-API tokens authenticate the endpoints below in place of the session cookie. Send the token as `Authorization: Bearer <token>`, `X-Api-Key: <token>`, or a `?token=<token>` query parameter (support varies by print-server client).
+API tokens authenticate the endpoints below in place of the session cookie. Send the token as `Authorization: Bearer <token>` or `X-Api-Key: <token>`. A `?token=` query parameter is not accepted: a token in the URL lands in proxy access logs.
 
 #### List API Tokens
 
@@ -1626,7 +1626,7 @@ Returned when an unexpected error occurs on the server.
 
 Most endpoints require authentication. To authenticate, include the JWT token in a cookie named `token`. The token is obtained by calling the `/api/auth/login` endpoint.
 
-The [Printer Integration](#printer-integration) endpoints (`/api/integrations/usage` and `/api/spoolman-compat/v1/*`) use a separate mechanism instead, since a print server can't hold a browser session cookie: a per-user **API token**, sent as `Authorization: Bearer <token>`, `X-Api-Key: <token>`, or a `?token=` query parameter. See [API Tokens](#api-tokens) for how to create one.
+The [Printer Integration](#printer-integration) endpoints (`/api/integrations/usage` and `/api/spoolman-compat/v1/*`) use a separate mechanism instead, since a print server can't hold a browser session cookie: a per-user **API token**, sent as `Authorization: Bearer <token>` or `X-Api-Key: <token>`. See [API Tokens](#api-tokens) for how to create one.
 
 ### Admin-Only Endpoints
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -172,14 +172,14 @@ export function hashApiToken(plaintext: string): string {
 
 // Authenticates requests via an API token instead of the session cookie, for
 // callers that can't hold a browser session (print servers). Accepts the
-// token as `Authorization: Bearer <token>`, `X-Api-Key: <token>`, or
-// `?token=<token>` - print-server HTTP clients vary in which they support.
+// token as `Authorization: Bearer <token>` or `X-Api-Key: <token>`. It used to
+// take `?token=` as well; a token in the URL ends up in proxy access logs and
+// print-server histories, where a header does not.
 export async function requireApiToken(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers.authorization;
   const token =
     (authHeader?.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : undefined) ||
-    (typeof req.headers["x-api-key"] === "string" ? req.headers["x-api-key"] : undefined) ||
-    (typeof req.query.token === "string" ? req.query.token : undefined);
+    (typeof req.headers["x-api-key"] === "string" ? req.headers["x-api-key"] : undefined);
 
   if (!token) {
     return res.status(401).json({ message: "API token required" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import cookieParser from "cookie-parser";
 import helmet from "helmet";
 import { registerRoutes } from "./routes/index";
@@ -6,6 +6,7 @@ import { setupVite, serveStatic, log } from "./vite";
 import { runScheduledChecks } from "./utils/notification-checks";
 import { startBackupScheduler } from "./backup-scheduler";
 import { logger } from "./utils/logger";
+import { errorHandler } from "./utils/error-handler";
 
 const app = express();
 
@@ -75,13 +76,7 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(errorHandler);
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route

--- a/server/routes/backups.ts
+++ b/server/routes/backups.ts
@@ -7,6 +7,7 @@ import { nanoid } from "nanoid";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { authenticate, isAdmin } from "../auth";
+import { sensitiveActionLimiter } from "../utils/rate-limits";
 import { storage } from "../storage";
 import { updateBackupSettingsSchema } from "@shared/schema";
 import { logger } from "../utils/logger";
@@ -207,7 +208,7 @@ export function registerBackupRoutes(app: Express): void {
   });
 
   // Trigger immediate backup snapshot to disk (admin only, SQLite only)
-  app.post("/api/admin/backups", authenticate, isAdmin, requireSqliteDialect, async (_req: Request, res: Response) => {
+  app.post("/api/admin/backups", authenticate, isAdmin, requireSqliteDialect, sensitiveActionLimiter, async (_req: Request, res: Response) => {
     try {
       const result = await createBackupFile();
       res.status(201).json(result);
@@ -218,7 +219,7 @@ export function registerBackupRoutes(app: Express): void {
   });
 
   // Stream a fresh snapshot directly without leaving a persistent file behind (admin only, SQLite only)
-  app.post("/api/admin/backups/stream", authenticate, isAdmin, requireSqliteDialect, async (_req: Request, res: Response) => {
+  app.post("/api/admin/backups/stream", authenticate, isAdmin, requireSqliteDialect, sensitiveActionLimiter, async (_req: Request, res: Response) => {
     const tempFile = path.join(os.tmpdir(), `filadex-snapshot-${nanoid()}.db`);
     const cleanup = () => {
       try {

--- a/server/routes/batch.ts
+++ b/server/routes/batch.ts
@@ -1,7 +1,9 @@
 import type { Express } from "express";
+import { ZodError } from "zod";
+import { fromZodError } from "zod-validation-error";
 import { storage } from "../storage";
 import { authenticate } from "../auth";
-import { InsertFilament } from "@shared/schema";
+import { InsertFilament, filamentPatchSchema } from "@shared/schema";
 import { logger as appLogger } from "../utils/logger";
 import { validateBatchIds } from "../utils/batch-operations";
 
@@ -56,30 +58,13 @@ export function registerBatchRoutes(app: Express): void {
         return res.status(400).json({ message: "No valid filament IDs provided" });
       }
 
-      // Prepare update data
-      const updateData: Partial<InsertFilament> = {};
-
-      // Process each field, ensuring proper type conversion
-      if (updates.name !== undefined) updateData.name = String(updates.name);
-      if (updates.manufacturer !== undefined) updateData.manufacturer = String(updates.manufacturer);
-      if (updates.material !== undefined) updateData.material = String(updates.material);
-      if (updates.colorName !== undefined) updateData.colorName = String(updates.colorName);
-      if (updates.colorCode !== undefined) updateData.colorCode = String(updates.colorCode);
-      if (updates.printTemp !== undefined) updateData.printTemp = String(updates.printTemp);
-
-      // Numeric values stored as strings
-      if (updates.diameter !== undefined) updateData.diameter = String(updates.diameter);
-      if (updates.totalWeight !== undefined) updateData.totalWeight = String(updates.totalWeight);
-      if (updates.remainingPercentage !== undefined) updateData.remainingPercentage = String(updates.remainingPercentage);
-
-      // Additional fields
-      if (updates.purchaseDate !== undefined) updateData.purchaseDate = updates.purchaseDate;
-      if (updates.purchasePrice !== undefined) updateData.purchasePrice = String(updates.purchasePrice);
-      if (updates.status !== undefined) updateData.status = String(updates.status);
-      if (updates.spoolType !== undefined) updateData.spoolType = String(updates.spoolType);
-      if (updates.dryerCount !== undefined) updateData.dryerCount = Number(updates.dryerCount);
-      if (updates.lastDryingDate !== undefined) updateData.lastDryingDate = updates.lastDryingDate;
-      if (updates.storageLocation !== undefined) updateData.storageLocation = String(updates.storageLocation);
+      // The same shape a single PATCH accepts. The fields a caller must not set
+      // - owner, type, the notification latches - are not in the schema.
+      const data = filamentPatchSchema.parse(updates ?? {});
+      const updateData: Partial<InsertFilament> = {
+        ...data,
+        diameter: data.diameter === undefined ? undefined : data.diameter === null ? null : data.diameter.toString(),
+      };
 
       const updatedCount = await storage.batchUpdateFilaments(validIds, updateData, req.userId);
 
@@ -90,6 +75,9 @@ export function registerBatchRoutes(app: Express): void {
         updatedCount
       });
     } catch (error) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({ message: fromZodError(error).message });
+      }
       appLogger.error("Error batch updating filaments:", error);
       res.status(500).json({ message: "Failed to update filaments" });
     }

--- a/server/routes/catalog-requests.ts
+++ b/server/routes/catalog-requests.ts
@@ -41,9 +41,11 @@ export function registerCatalogRequestRoutes(app: Express): void {
 
       // Validate the payload matches the shape expected for this entity type
       // before it ever reaches an admin's review queue.
-      ENTITY_CONFIG[entityType].schema.parse(payload);
+      // Stored as parsed, so only the fields the entity knows reach the review
+      // queue and the row, not whatever else came with the request.
+      const validatedPayload = ENTITY_CONFIG[entityType].schema.parse(payload);
 
-      const created = await storage.createCatalogRequest(req.userId, entityType, payload);
+      const created = await storage.createCatalogRequest(req.userId, entityType, validatedPayload);
 
       res.status(201).json(created);
     } catch (error) {

--- a/server/routes/community-filaments.ts
+++ b/server/routes/community-filaments.ts
@@ -3,6 +3,7 @@ import { authenticate, isAdmin } from "../auth";
 import { storage } from "../storage";
 import { refreshCommunityFilamentCache, searchCommunityFilaments } from "../utils/spoolmandb-sync";
 import { logger as appLogger } from "../utils/logger";
+import { sensitiveActionLimiter } from "../utils/rate-limits";
 
 export function registerCommunityFilamentRoutes(app: Express): void {
   app.get("/api/community-filaments/search", authenticate, async (req, res) => {
@@ -28,7 +29,7 @@ export function registerCommunityFilamentRoutes(app: Express): void {
     }
   });
 
-  app.post("/api/community-filaments/refresh", authenticate, isAdmin, async (_req, res) => {
+  app.post("/api/community-filaments/refresh", authenticate, isAdmin, sensitiveActionLimiter, async (_req, res) => {
     try {
       const count = await refreshCommunityFilamentCache();
       res.json({ count });

--- a/server/routes/email-settings.ts
+++ b/server/routes/email-settings.ts
@@ -7,6 +7,7 @@ import { logger as appLogger } from "../utils/logger";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { getAppUrl } from "../utils/app-url";
+import { sensitiveActionLimiter } from "../utils/rate-limits";
 
 export function registerEmailSettingsRoutes(app: Express): void {
   // Get current email settings (admin only). Never returns the SMTP password.
@@ -49,7 +50,7 @@ export function registerEmailSettingsRoutes(app: Express): void {
   });
 
   // Send a test email to confirm the configured SMTP settings actually work (admin only).
-  app.post("/api/settings/email/test", authenticate, isAdmin, async (req, res) => {
+  app.post("/api/settings/email/test", authenticate, isAdmin, sensitiveActionLimiter, async (req, res) => {
     try {
       const to = req.body?.to || req.user?.username;
       if (!to || typeof to !== "string" || !to.includes("@")) {

--- a/server/routes/filaments.ts
+++ b/server/routes/filaments.ts
@@ -1,12 +1,16 @@
 import type { Express } from "express";
 import { storage } from "../storage";
 import { authenticate } from "../auth";
-import { InsertFilament } from "@shared/schema";
-import { ZodError } from "zod";
+import { InsertFilament, filamentWriteSchema, filamentPatchSchema } from "@shared/schema";
+import { ZodError, z } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { logger as appLogger } from "../utils/logger";
 import { validateId } from "../utils/validation";
 import { parseCSVLine, detectCSVFormat, escapeCsvField } from "../utils/csv-parser";
+
+// Each imported row costs several queries, and the only bound used to be the
+// 100 kB body limit - some fifteen thousand minimal rows in one request.
+const MAX_IMPORT_ROWS = 2000;
 
 export function registerFilamentRoutes(app: Express): void {
   // GET all filaments with optional export
@@ -93,6 +97,9 @@ export function registerFilamentRoutes(app: Express): void {
 
         // Parse CSV data
         const csvLines = req.body.csvData.split('\n').filter((line: string) => line.trim().length > 0);
+        if (csvLines.length > MAX_IMPORT_ROWS) {
+          return res.status(400).json({ message: `Import at most ${MAX_IMPORT_ROWS} rows at a time` });
+        }
 
         // Expected columns in the CSV
         const expectedColumns = [
@@ -205,6 +212,9 @@ export function registerFilamentRoutes(app: Express): void {
           if (!Array.isArray(filaments)) {
             return res.status(400).json({ message: "Invalid JSON format. Expected an array of filaments." });
           }
+          if (filaments.length > MAX_IMPORT_ROWS) {
+            return res.status(400).json({ message: `Import at most ${MAX_IMPORT_ROWS} rows at a time` });
+          }
 
           // Get existing filaments to check for duplicates
           const existingFilaments = await storage.getFilaments(req.userId);
@@ -271,7 +281,7 @@ export function registerFilamentRoutes(app: Express): void {
       // Regular single filament creation
       appLogger.debug("Creating filament", { userId: req.userId });
 
-      const data = req.body;
+      const data = filamentWriteSchema.parse(req.body);
       const insertData: InsertFilament = {
         userId: req.userId,
         name: data.name,
@@ -280,11 +290,11 @@ export function registerFilamentRoutes(app: Express): void {
         colorName: data.colorName,
         colorCode: data.colorCode,
         printTemp: data.printTemp,
-        diameter: data.diameter ? data.diameter.toString() : undefined,
-        totalWeight: data.totalWeight.toString(),
-        remainingPercentage: data.remainingPercentage.toString(),
+        diameter: data.diameter !== undefined && data.diameter !== null ? data.diameter.toString() : undefined,
+        totalWeight: data.totalWeight,
+        remainingPercentage: data.remainingPercentage,
         purchaseDate: data.purchaseDate,
-        purchasePrice: data.purchasePrice ? data.purchasePrice.toString() : undefined,
+        purchasePrice: data.purchasePrice ?? undefined,
         status: data.status,
         spoolType: data.spoolType,
         dryerCount: data.dryerCount,
@@ -342,7 +352,9 @@ export function registerFilamentRoutes(app: Express): void {
         return res.status(404).json({ message: "Filament not found" });
       }
 
-      const data = req.body;
+      // `note` is not a column: it annotates the usage-log entry a change in
+      // remaining percentage writes below.
+      const data = filamentPatchSchema.extend({ note: z.string().max(500).optional() }).parse(req.body);
       const updateData: Partial<InsertFilament> = {};
 
       if (data.name !== undefined) updateData.name = data.name;
@@ -353,13 +365,13 @@ export function registerFilamentRoutes(app: Express): void {
       if (data.printTemp !== undefined) updateData.printTemp = data.printTemp;
 
       // Numeric values stored as strings
-      if (data.diameter !== undefined) updateData.diameter = data.diameter.toString();
-      if (data.totalWeight !== undefined) updateData.totalWeight = data.totalWeight.toString();
-      if (data.remainingPercentage !== undefined) updateData.remainingPercentage = data.remainingPercentage.toString();
+      if (data.diameter !== undefined) updateData.diameter = data.diameter === null ? null : data.diameter.toString();
+      if (data.totalWeight !== undefined) updateData.totalWeight = data.totalWeight;
+      if (data.remainingPercentage !== undefined) updateData.remainingPercentage = data.remainingPercentage;
 
       // Additional fields
       if (data.purchaseDate !== undefined) updateData.purchaseDate = data.purchaseDate;
-      if (data.purchasePrice !== undefined) updateData.purchasePrice = data.purchasePrice.toString();
+      if (data.purchasePrice !== undefined) updateData.purchasePrice = data.purchasePrice;
       if (data.status !== undefined) updateData.status = data.status;
       if (data.spoolType !== undefined) updateData.spoolType = data.spoolType;
       if (data.dryerCount !== undefined) updateData.dryerCount = data.dryerCount;

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -3,10 +3,34 @@ import { storage } from "../storage";
 import { logger as appLogger } from "../utils/logger";
 import { validateId } from "../utils/validation";
 import { isOneOfMaterials } from "../utils/materials";
+import { publicReadLimiter } from "../utils/rate-limits";
+import type { Filament } from "@shared/schema";
+
+// What a share shows: the product, not the purchase. The row also carries the
+// price, the purchase date, the storage location, the custom-field values and
+// the notification timestamps, none of which the public page renders - so the
+// owner had no way to know they were public.
+function publicFilament(filament: Filament) {
+  return {
+    id: filament.id,
+    name: filament.name,
+    manufacturer: filament.manufacturer,
+    material: filament.material,
+    colorName: filament.colorName,
+    colorCode: filament.colorCode,
+    diameter: filament.diameter,
+    printTemp: filament.printTemp,
+    remainingPercentage: filament.remainingPercentage,
+  };
+}
+
+// One answer for "no such user" and "shares nothing", so the endpoint cannot be
+// used to list which ids are accounts.
+const NOTHING_SHARED = { message: "No public filaments found" };
 
 export function registerPublicRoutes(app: Express): void {
   // Get public filaments for a specific user by ID
-  app.get("/api/public/filaments/:userId", async (req, res) => {
+  app.get("/api/public/filaments/:userId", publicReadLimiter, async (req, res) => {
     try {
       const userId = validateId(req.params.userId);
       if (userId === null) {
@@ -17,7 +41,7 @@ export function registerPublicRoutes(app: Express): void {
       const user = await storage.getUser(userId);
 
       if (!user) {
-        return res.status(404).json({ message: "User not found" });
+        return res.status(404).json(NOTHING_SHARED);
       }
 
       // Get user's sharing settings
@@ -25,7 +49,7 @@ export function registerPublicRoutes(app: Express): void {
 
       // Check if user has any public filaments
       if (sharingSettings.length === 0) {
-        return res.status(404).json({ message: "No public filaments found" });
+        return res.status(404).json(NOTHING_SHARED);
       }
 
       // Check if user has global sharing enabled
@@ -51,7 +75,7 @@ export function registerPublicRoutes(app: Express): void {
 
       // Return filaments with user information
       res.json({
-        filaments: publicFilaments,
+        filaments: publicFilaments.map(publicFilament),
         user: {
           id: user.id,
           username: user.username

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,5 +1,5 @@
 import type { Express } from "express";
-import { type User, adminCreateUserSchema, adminUpdateUserSchema, usernameSchema } from "../../shared/schema";
+import { type User, adminCreateUserSchema, adminUpdateUserSchema, usernameSchema, userSharingSchema } from "../../shared/schema";
 import { formatSupportedLanguages, isSupportedLanguage } from "@shared/languages";
 import { authenticate, isAdmin, hashPassword } from "../auth";
 import { storage, type UserChanges, type UserPreferences } from "../storage";
@@ -295,13 +295,22 @@ export function registerUserRoutes(app: Express): void {
 
   app.post("/api/user-sharing", authenticate, async (req, res) => {
     try {
-      const { materialId, isPublic } = req.body;
+      const parsed = userSharingSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ message: parsed.error.errors[0]?.message || "Invalid input" });
+      }
+      const { materialId = null, isPublic = false } = parsed.data;
 
-      const newSharing = await storage.setUserSharing(
-        req.userId,
-        materialId ?? null,
-        isPublic || false,
-      );
+      // A per-material share names a catalog row the caller can see: the
+      // Global Catalog or their own. Anything else is a typo or a probe.
+      if (materialId !== null) {
+        const visible = await storage.getMaterials(req.userId);
+        if (!visible.some((material) => material.id === materialId)) {
+          return res.status(400).json({ message: "Unknown material" });
+        }
+      }
+
+      const newSharing = await storage.setUserSharing(req.userId, materialId, isPublic);
 
       res.status(201).json(newSharing);
     } catch (error) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -329,6 +329,8 @@ export interface IStorage {
 
   // Filament operations
   getFilaments(userId: number): Promise<Filament[]>;
+  /** Every user's spools - for deciding whether a Global Catalog row is in use. */
+  getFilamentsOfAllUsers(): Promise<Filament[]>;
   getFilament(id: number, userId: number): Promise<Filament | undefined>;
   createFilament(filament: InsertFilament): Promise<Filament>;
   updateFilament(id: number, filament: Partial<InsertFilament>, userId: number): Promise<Filament | undefined>;
@@ -783,6 +785,11 @@ export class DatabaseStorage implements IStorage {
     return await db.select(FILAMENT_SELECT_COLUMNS).from(filaments)
       .innerJoin(filamentTypes, eq(filaments.filamentTypeId, filamentTypes.id))
       .where(eq(filaments.userId, userId));
+  }
+
+  async getFilamentsOfAllUsers(): Promise<Filament[]> {
+    return await db.select(FILAMENT_SELECT_COLUMNS).from(filaments)
+      .innerJoin(filamentTypes, eq(filaments.filamentTypeId, filamentTypes.id));
   }
 
   async getFilament(id: number, userId: number): Promise<Filament | undefined> {

--- a/server/utils/csv-parser.ts
+++ b/server/utils/csv-parser.ts
@@ -80,9 +80,17 @@ export function detectCSVFormat(
  */
 export function escapeCsvField(field: unknown): string {
   if (field === null || field === undefined) return '';
-  const str = String(field);
-  return str.includes(',') || str.includes('"') || str.includes('\n') 
-    ? `"${str.replace(/"/g, '""')}"` 
+  let str = String(field);
+  // A cell that starts with = + - @ or a tab is a formula to Excel and
+  // LibreOffice, and a spool named `=HYPERLINK(...)` would run when the export
+  // is opened. A leading apostrophe makes it text. Plain numbers keep their
+  // minus sign, since they are the one thing a spreadsheet should still treat
+  // as a number.
+  if (/^[=+\-@\t\r]/.test(str) && !/^-?\d+(\.\d+)?$/.test(str)) {
+    str = `'${str}`;
+  }
+  return /[",\n\r]/.test(str)
+    ? `"${str.replace(/"/g, '""')}"`
     : str;
 }
 

--- a/server/utils/error-handler.ts
+++ b/server/utils/error-handler.ts
@@ -1,0 +1,36 @@
+import type { Request, Response, NextFunction } from "express";
+import { logger } from "./logger";
+
+/**
+ * The last handler. Answers with a fixed message per class of error and logs
+ * the rest server-side.
+ *
+ * The previous version rethrew after responding. Express caught that, saw the
+ * headers were already sent, destroyed the socket and printed the stack -
+ * on every malformed JSON body. It also echoed body-parser's message, which
+ * is a detail about the parser, not about the request.
+ */
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+  const error = (err ?? {}) as { status?: number; statusCode?: number; type?: string; message?: string };
+  const status = error.status || error.statusCode || 500;
+
+  if (res.headersSent) {
+    return;
+  }
+
+  if (error.type === "entity.parse.failed") {
+    res.status(400).json({ message: "Request body is not valid JSON" });
+    return;
+  }
+  if (error.type === "entity.too.large" || status === 413) {
+    res.status(413).json({ message: "Request body is too large" });
+    return;
+  }
+  if (status >= 500) {
+    logger.error("Unhandled error:", err);
+    res.status(status).json({ message: "Internal Server Error" });
+    return;
+  }
+
+  res.status(status).json({ message: error.message || "Request failed" });
+}

--- a/server/utils/rate-limits.ts
+++ b/server/utils/rate-limits.ts
@@ -23,6 +23,17 @@ export const loginLimiter = rateLimit({
   message: { message: "Too many login attempts, please try again later" },
 });
 
+// The anonymous share page. Generous, since one shared link may be opened by
+// many people behind one address, but bounded, since the user id in the path
+// is a small integer and the endpoint otherwise enumerates accounts for free.
+export const publicReadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many requests, please try again later" },
+});
+
 // Authenticated actions that mint credentials or do expensive work per call:
 // API token creation, backups, cache refresh, test mail.
 export const sensitiveActionLimiter = rateLimit({

--- a/server/utils/settings-crud.ts
+++ b/server/utils/settings-crud.ts
@@ -212,7 +212,15 @@ export function registerCrudSettingsRoutes<T extends { id: number; userId?: numb
         return res.status(403).json({ message: `Cannot delete a ${entityName} you do not own` });
       }
 
-      const filaments = await storage.getFilaments(req.userId);
+      // A Global Catalog row - every row of a non-scoped entity, and a
+      // materials row nobody owns - is shared by every user, so every user's
+      // spools decide whether it is in use. Checking only the admin's own let
+      // a material other people's spools referenced be deleted, and its
+      // cascade took their per-material sharing rows with it.
+      const isGlobalRow = !userScoped || (item as { userId?: number | null }).userId == null;
+      const filaments = isGlobalRow
+        ? await storage.getFilamentsOfAllUsers()
+        : await storage.getFilaments(req.userId);
       if (filaments.some((f) => isInUse(f, item))) {
         return res.status(400).json({
           message: `Cannot delete ${entityName} that is in use by filaments`,

--- a/server/utils/spoolmandb-sync.ts
+++ b/server/utils/spoolmandb-sync.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { type CommunityFilamentCacheEntry } from "@shared/schema";
 import { storage, type NewCommunityFilament } from "../storage";
 import { logger } from "./logger";
@@ -5,44 +6,78 @@ import { logger } from "./logger";
 const REPO = "Donkie/SpoolmanDB";
 const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main`;
 
-interface SpoolmanDbColor {
-  name: string;
-  hex: string;
-}
+// The upstream is trusted to be SpoolmanDB, not to be well-formed: a request
+// that never answers, a response that never ends, or a file whose shape has
+// changed must each fail that one file or that one refresh, not hang the
+// server or fill the cache with whatever arrived.
+const FETCH_TIMEOUT_MS = 20_000;
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 
-interface SpoolmanDbFilament {
-  name: string;
-  material: string;
-  density?: number;
-  diameters?: number[];
-  extruder_temp?: number;
-  bed_temp?: number;
-  colors?: SpoolmanDbColor[];
-}
+const spoolmanDbColorSchema = z.object({
+  name: z.string().max(200),
+  hex: z.string().max(20).optional().default(""),
+});
 
-interface SpoolmanDbVendorFile {
-  manufacturer: string;
-  filaments: SpoolmanDbFilament[];
+const spoolmanDbFilamentSchema = z.object({
+  name: z.string().max(300),
+  material: z.string().max(100),
+  density: z.number().optional(),
+  diameters: z.array(z.number()).optional(),
+  extruder_temp: z.number().int().optional(),
+  bed_temp: z.number().int().optional(),
+  colors: z.array(spoolmanDbColorSchema).optional(),
+});
+
+const spoolmanDbVendorFileSchema = z.object({
+  manufacturer: z.string().max(200),
+  filaments: z.array(spoolmanDbFilamentSchema),
+});
+
+type SpoolmanDbFilament = z.infer<typeof spoolmanDbFilamentSchema>;
+type SpoolmanDbVendorFile = z.infer<typeof spoolmanDbVendorFileSchema>;
+
+const treeSchema = z.object({
+  tree: z.array(z.object({ path: z.string(), type: z.string() })),
+});
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error(`response larger than ${MAX_RESPONSE_BYTES} bytes`);
+  }
+  return JSON.parse(text);
 }
 
 async function fetchVendorFilePaths(): Promise<string[]> {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/git/trees/main?recursive=1`);
-  if (!res.ok) {
-    throw new Error(`Failed to list SpoolmanDB tree: ${res.status} ${res.statusText}`);
+  let data: unknown;
+  try {
+    data = await fetchJson(`https://api.github.com/repos/${REPO}/git/trees/main?recursive=1`);
+  } catch (error) {
+    throw new Error(`Failed to list SpoolmanDB tree: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
   }
-  const data = await res.json() as { tree: Array<{ path: string; type: string }> };
-  return data.tree
+  return treeSchema.parse(data).tree
     .filter((entry) => entry.type === "blob" && entry.path.startsWith("filaments/") && entry.path.endsWith(".json"))
     .map((entry) => entry.path);
 }
 
 async function fetchVendorFile(path: string): Promise<SpoolmanDbVendorFile | null> {
-  const res = await fetch(`${RAW_BASE}/${path}`);
-  if (!res.ok) {
-    logger.warn(`Failed to fetch SpoolmanDB file ${path}: ${res.status}`);
+  let data: unknown;
+  try {
+    data = await fetchJson(`${RAW_BASE}/${path}`);
+  } catch (error) {
+    logger.warn(`Failed to fetch SpoolmanDB file ${path}: ${error instanceof Error ? error.message : String(error)}`);
     return null;
   }
-  return await res.json() as SpoolmanDbVendorFile;
+  const parsed = spoolmanDbVendorFileSchema.safeParse(data);
+  if (!parsed.success) {
+    logger.warn(`Skipping SpoolmanDB file ${path}: ${parsed.error.errors[0]?.message ?? "unexpected shape"}`);
+    return null;
+  }
+  return parsed.data;
 }
 
 function toCacheRows(vendorFile: SpoolmanDbVendorFile): NewCommunityFilament[] {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -358,6 +358,60 @@ export const insertFilamentSchema = baseInsertFilamentSchema.transform((data) =>
   };
 });
 
+// What a spool write may carry, checked at the HTTP boundary. The routes used
+// to copy fields off req.body one by one - which kept ownership and the
+// notification latches out of a caller's reach, but let a status of "bogus", a
+// purchase date of "yesterday" or a string where custom-field values belong
+// straight into the row. Numbers may arrive as strings or numbers, since the
+// form, the imports and the print-server clients disagree; the database
+// stores them as text either way.
+const numberish = (min: number, max?: number) => z.union([z.string(), z.number()])
+  .transform((value) => String(value).trim())
+  .refine((value) => value !== "" && Number.isFinite(Number(value)), { message: "must be a number" })
+  .refine((value) => Number(value) >= min, { message: `must be at least ${min}` })
+  .refine((value) => max === undefined || Number(value) <= max, { message: `must be at most ${max}` });
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "must be a date in YYYY-MM-DD form");
+
+export const filamentStatuses = ["sealed", "opened"] as const;
+export const spoolTypes = ["spooled", "spoolless"] as const;
+
+// Values for the caller's custom fields, keyed by definition id. Scalars only,
+// bounded in count and length, so the JSON column cannot become a dumping
+// ground for arbitrary documents.
+export const customFieldValuesSchema = z.record(
+  z.string().max(20),
+  z.union([z.string().max(1000), z.number(), z.boolean(), z.null()]),
+).refine((values) => Object.keys(values).length <= 50, { message: "too many custom field values" });
+
+export const filamentWriteSchema = z.object({
+  name: z.string().trim().min(1, "name is required").max(200),
+  manufacturer: z.string().max(200).nullable().optional(),
+  material: z.string().trim().min(1, "material is required").max(100),
+  colorName: z.string().max(100),
+  colorCode: z.string().max(20).nullable().optional(),
+  printTemp: z.union([z.string().max(50), z.number()]).transform((v) => String(v)).optional(),
+  diameter: diameterValueSchema.nullable().optional(),
+  totalWeight: numberish(0),
+  remainingPercentage: numberish(0, 100),
+  purchaseDate: isoDate.nullable().optional(),
+  purchasePrice: numberish(0).nullable().optional(),
+  status: z.enum(filamentStatuses).nullable().optional(),
+  spoolType: z.enum(spoolTypes).nullable().optional(),
+  dryerCount: z.number().int().min(0).max(10_000).optional(),
+  lastDryingDate: isoDate.nullable().optional(),
+  storageLocation: z.string().max(200).nullable().optional(),
+  customFieldValues: customFieldValuesSchema.optional(),
+});
+
+export const filamentPatchSchema = filamentWriteSchema.partial();
+
+// One sharing setting: the whole collection (materialId null) or one material.
+export const userSharingSchema = z.object({
+  materialId: z.number().int().positive().nullable().optional(),
+  isPublic: z.boolean().optional(),
+});
+
 // Neue Listen für die Einstellungen
 export const manufacturers = table("manufacturers", {
   id: t.pk("id"),

--- a/tests/routes/community-filaments.test.ts
+++ b/tests/routes/community-filaments.test.ts
@@ -20,6 +20,10 @@ import { db } from "../helpers/db";
 import { communityFilamentCache } from "../../shared/schema";
 import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
+// The sync reads the body as text - so it can refuse an oversized one before
+// parsing - and then parses it itself. What a stubbed fetch has to answer with.
+const jsonResponse = (body: unknown) => ({ ok: true, json: async () => body, text: async () => JSON.stringify(body) });
+
 let app: Express;
 let adminCookie: string;
 let userCookie: string;
@@ -137,11 +141,11 @@ describe("refreshCommunityFilamentCache", () => {
       "fetch",
       vi.fn(async (url: string) => {
         if (url.includes("api.github.com")) {
-          return { ok: true, json: async () => ({ tree }) };
+          return jsonResponse(({ tree }));
         }
         const path = Object.keys(vendorFiles).find((p) => url.endsWith(p));
         if (!path) return { ok: false, status: 404, statusText: "Not Found" };
-        return { ok: true, json: async () => vendorFiles[path] };
+        return jsonResponse(vendorFiles[path]);
       }),
     );
   }
@@ -262,6 +266,17 @@ describe("refreshCommunityFilamentCache", () => {
     expect(stored).toHaveLength(1200);
   });
 
+  it("skips a vendor file whose shape is not what SpoolmanDB publishes", async () => {
+    stubSpoolmanDb({
+      "filaments/good.json": { manufacturer: "Good", filaments: [{ name: "Fine", material: "PLA", colors: [{ name: "Black", hex: "000000" }] }] },
+      "filaments/odd.json": { vendor: "Odd", items: "nope" },
+    });
+
+    const count = await refreshCommunityFilamentCache();
+
+    expect(count).toBe(1);
+  });
+
   it("skips a vendor file it cannot fetch, keeping the rest", async () => {
     const tree = [
       { path: "filaments/good.json", type: "blob" },
@@ -270,15 +285,12 @@ describe("refreshCommunityFilamentCache", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) => {
-        if (url.includes("api.github.com")) return { ok: true, json: async () => ({ tree }) };
+        if (url.includes("api.github.com")) return jsonResponse(({ tree }));
         if (url.endsWith("good.json")) {
-          return {
-            ok: true,
-            json: async () => ({
+          return jsonResponse(({
               manufacturer: "Good",
               filaments: [{ name: "Fine", material: "PLA", colors: [{ name: "Black", hex: "000000" }] }],
-            }),
-          };
+            }));
         }
         return { ok: false, status: 404, statusText: "Not Found" };
       }),
@@ -307,14 +319,11 @@ describe("refreshCommunityFilamentCache", () => {
       { path: "filaments", type: "tree" },
     ];
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.includes("api.github.com")) return { ok: true, json: async () => ({ tree }) };
-      return {
-        ok: true,
-        json: async () => ({
+      if (url.includes("api.github.com")) return jsonResponse(({ tree }));
+      return jsonResponse(({
           manufacturer: "Good",
           filaments: [{ name: "Fine", material: "PLA", colors: [{ name: "Black", hex: "000000" }] }],
-        }),
-      };
+        }));
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -411,15 +420,12 @@ describe("POST /api/community-filaments/refresh", () => {
       "fetch",
       vi.fn(async (url: string) => {
         if (url.includes("api.github.com")) {
-          return { ok: true, json: async () => ({ tree: [{ path: "filaments/x.json", type: "blob" }] }) };
+          return jsonResponse(({ tree: [{ path: "filaments/x.json", type: "blob" }] }));
         }
-        return {
-          ok: true,
-          json: async () => ({
+        return jsonResponse(({
             manufacturer: "X",
             filaments: [{ name: "N", material: "PLA", colors: [{ name: "Black", hex: "000000" }] }],
-          }),
-        };
+          }));
       }),
     );
 

--- a/tests/routes/filament-writes.test.ts
+++ b/tests/routes/filament-writes.test.ts
@@ -1,0 +1,116 @@
+/**
+ * What a spool write may carry. The routes used to copy fields off the body
+ * one by one, which kept ownership out of reach but let any value through.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+import { registerAuthRoutes } from "../../server/routes/auth";
+import { registerBatchRoutes } from "../../server/routes/batch";
+import { registerFilamentRoutes } from "../../server/routes/filaments";
+import { createApp, registerAndVerify } from "../helpers/app";
+
+let app: Express;
+let cookie: string;
+
+// Mock credentials for a throwaway test database - not a real login anywhere, so
+// the password below is safe to keep in the repository (hence the ggignore tag).
+const alice = { username: "alice", email: "alice@example.com", password: "correct-horse" }; // ggignore
+
+const spool = {
+  name: "Orange PETG",
+  manufacturer: "Prusament",
+  material: "PETG",
+  colorName: "Orange",
+  colorCode: "#EA580C",
+  diameter: 1.75,
+  totalWeight: 1000,
+  remainingPercentage: "100",
+  status: "sealed",
+  spoolType: "spooled",
+};
+
+beforeEach(async () => {
+  // Batch before filaments, as registerRoutes does, or /batch matches /:id.
+  app = createApp(registerAuthRoutes, registerBatchRoutes, registerFilamentRoutes);
+  cookie = await registerAndVerify(app, alice);
+});
+
+async function create(body: Record<string, unknown> = spool) {
+  return request(app).post("/api/filaments").set("Cookie", cookie).send(body);
+}
+
+describe("POST /api/filaments", () => {
+  it("accepts numbers as numbers or strings and stores them as text", async () => {
+    const res = await create();
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ totalWeight: "1000", remainingPercentage: "100", diameter: "1.75", status: "sealed" });
+  });
+
+  it("refuses a status outside the known set", async () => {
+    const res = await create({ ...spool, status: "bogus" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/status/);
+  });
+
+  it("refuses a purchase date that is not a date", async () => {
+    const res = await create({ ...spool, purchaseDate: "yesterday" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses a percentage above 100 and a negative weight", async () => {
+    expect((await create({ ...spool, remainingPercentage: 150 })).status).toBe(400);
+    expect((await create({ ...spool, totalWeight: -1 })).status).toBe(400);
+  });
+
+  it("refuses custom-field values that are not a map of scalars", async () => {
+    expect((await create({ ...spool, customFieldValues: "not-an-object" })).status).toBe(400);
+    expect((await create({ ...spool, customFieldValues: { "1": { nested: true } } })).status).toBe(400);
+    expect((await create({ ...spool, customFieldValues: { "1": "shelf B", "2": 3, "3": true } })).status).toBe(201);
+  });
+
+  it("answers 400, not 500, when the required fields are missing", async () => {
+    const res = await create({ name: "x" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("caps an import at 2000 rows", async () => {
+    // Minimal rows, so the cap is what answers and not the body-size limit.
+    const csvData = ["name,manufacturer,material", ...Array.from({ length: 2001 }, (_, i) => `s${i},m,PLA`)].join("\n");
+    const res = await request(app)
+      .post("/api/filaments?import=csv")
+      .set("Cookie", cookie)
+      .send({ csvData });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Import at most 2000 rows at a time");
+  });
+});
+
+describe("PATCH /api/filaments/:id and /batch", () => {
+  it("validates a patch the same way", async () => {
+    const { body: created } = await create();
+
+    const bad = await request(app).patch(`/api/filaments/${created.id}`).set("Cookie", cookie).send({ spoolType: "cardboard" });
+    expect(bad.status).toBe(400);
+
+    const good = await request(app).patch(`/api/filaments/${created.id}`).set("Cookie", cookie).send({ remainingPercentage: 40, note: "used some" });
+    expect(good.status).toBe(200);
+    expect(good.body.remainingPercentage).toBe("40");
+  });
+
+  it("validates a batch update the same way", async () => {
+    const { body: created } = await create();
+
+    const bad = await request(app).patch("/api/filaments/batch").set("Cookie", cookie).send({ ids: [created.id], updates: { status: "bogus" } });
+    expect(bad.status).toBe(400);
+
+    const good = await request(app).patch("/api/filaments/batch").set("Cookie", cookie).send({ ids: [created.id], updates: { storageLocation: "Shelf B" } });
+    expect(good.status).toBe(200);
+    expect(good.body.updatedCount).toBe(1);
+  });
+});

--- a/tests/routes/integrations.test.ts
+++ b/tests/routes/integrations.test.ts
@@ -1,0 +1,47 @@
+/**
+ * API tokens identify a print server to /api/integrations/* and the
+ * Spoolman-compatible routes in place of a session cookie.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+import { registerAuthRoutes } from "../../server/routes/auth";
+import { registerIntegrationRoutes } from "../../server/routes/integrations";
+import { registerSpoolmanCompatRoutes } from "../../server/routes/spoolman-compat";
+import { createApp, registerAndVerify } from "../helpers/app";
+
+let app: Express;
+let token: string;
+
+// Mock credentials for a throwaway test database - not a real login anywhere, so
+// the password below is safe to keep in the repository (hence the ggignore tag).
+const alice = { username: "alice", email: "alice@example.com", password: "correct-horse" }; // ggignore
+
+beforeEach(async () => {
+  app = createApp(registerAuthRoutes, registerIntegrationRoutes, registerSpoolmanCompatRoutes);
+  const cookie = await registerAndVerify(app, alice);
+  const created = await request(app).post("/api/api-tokens").set("Cookie", cookie).send({ label: "printer" });
+  expect(created.status).toBe(201);
+  token = created.body.token;
+});
+
+describe("an API token", () => {
+  it("is accepted as a bearer token", async () => {
+    await request(app).get("/api/spoolman-compat/v1/spool").set("Authorization", `Bearer ${token}`).expect(200);
+  });
+
+  it("is accepted in X-Api-Key", async () => {
+    await request(app).get("/api/spoolman-compat/v1/spool").set("X-Api-Key", token).expect(200);
+  });
+
+  // A token in the URL lands in proxy access logs and print-server histories.
+  it("is not accepted in the query string", async () => {
+    const res = await request(app).get("/api/spoolman-compat/v1/spool").query({ token });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("does not open the session-only routes", async () => {
+    await request(app).get("/api/api-tokens").set("Authorization", `Bearer ${token}`).expect(401);
+  });
+});

--- a/tests/routes/public.test.ts
+++ b/tests/routes/public.test.ts
@@ -59,11 +59,37 @@ describe("GET /api/public/filaments/:userId", () => {
     expect(response.body.message).toBe("Invalid user ID");
   });
 
-  it("reports an unknown user as not found", async () => {
+  // The same answer as for a user who shares nothing, so the endpoint cannot be
+  // used to list which ids are accounts.
+  it("answers an unknown user exactly like a user who shares nothing", async () => {
     const response = await request(app).get("/api/public/filaments/9999");
 
     expect(response.status).toBe(404);
-    expect(response.body.message).toBe("User not found");
+    expect(response.body.message).toBe("No public filaments found");
+  });
+
+  it("shows the product, not the purchase", async () => {
+    await storage.createFilament({
+      userId: aliceId,
+      name: "Orange PETG",
+      material: "PETG",
+      colorName: "Orange",
+      totalWeight: "1000",
+      remainingPercentage: "80",
+      purchasePrice: "29.99",
+      purchaseDate: "2026-01-01",
+      storageLocation: "Top shelf, left",
+      customFieldValues: { "1": "batch 7" },
+    });
+    await share(aliceCookie, { isPublic: true });
+
+    const response = await request(app).get(`/api/public/filaments/${aliceId}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.filaments).toHaveLength(1);
+    expect(Object.keys(response.body.filaments[0]).sort()).toEqual([
+      "colorCode", "colorName", "diameter", "id", "manufacturer", "material", "name", "printTemp", "remainingPercentage",
+    ]);
   });
 
   it("reports a user who has shared nothing as having no public filaments", async () => {

--- a/tests/routes/settings.test.ts
+++ b/tests/routes/settings.test.ts
@@ -182,6 +182,25 @@ describe("DELETE /api/materials/:id", () => {
     expect(await allMaterialRows()).toHaveLength(1);
   });
 
+  it("blocks an admin deleting a Global Catalog row another user's Spool uses", async () => {
+    const alice = await newUser("alice");
+    const shared = await storage.createMaterial({ name: "SharedPETG" });
+    await storage.createFilament({
+      userId: alice.id,
+      name: "spool",
+      material: "SharedPETG",
+      colorName: "Black",
+      totalWeight: "1000",
+      remainingPercentage: "50",
+    });
+
+    // The admin owns no spool of it; the check used to look only at theirs.
+    const res = await request(app).delete(`/api/materials/${shared.id}`).set("Cookie", adminCookie);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/in use/);
+  });
+
   it("still blocks deleting a Catalog Material one of the caller's Spools uses", async () => {
     const alice = await newUser("alice");
     const [row] = await db.insert(materials).values({ userId: alice.id, name: "InUse" }).returning();

--- a/tests/routes/users.test.ts
+++ b/tests/routes/users.test.ts
@@ -13,6 +13,8 @@ import { registerAuthRoutes } from "../../server/routes/auth";
 import { registerUserRoutes } from "../../server/routes/users";
 import { hashPassword, initializeAdminUser } from "../../server/auth";
 import { storage } from "../../server/storage";
+import { db } from "../helpers/db";
+import { materials } from "../../shared/schema";
 import { createApp, loginAs, registerAndVerify, bootstrapAdmin } from "../helpers/app";
 
 let app: Express;
@@ -924,5 +926,35 @@ describe("POST /api/user-sharing for a global share", () => {
 
     const listed = await request(app).get("/api/user-sharing").set("Cookie", cookie);
     expect(listed.body).toHaveLength(2);
+  });
+});
+
+describe("POST /api/user-sharing", () => {
+  it("refuses a material id that is not a positive integer", async () => {
+    const cookie = await registerAndVerify(app, alice);
+
+    const res = await request(app).post("/api/user-sharing").set("Cookie", cookie).send({ materialId: "1; drop", isPublic: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses a material the caller cannot see", async () => {
+    const cookie = await registerAndVerify(app, alice);
+    const bobCookie = await registerAndVerify(app, { username: "bob", email: "bob@example.com", password: "bobs-password" });
+    const bob = await request(app).get("/api/auth/me").set("Cookie", bobCookie);
+    const [bobsMaterial] = await db.insert(materials).values({ userId: bob.body.id, name: "BobOnly" }).returning();
+
+    const res = await request(app).post("/api/user-sharing").set("Cookie", cookie).send({ materialId: bobsMaterial.id, isPublic: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Unknown material");
+  });
+
+  it("accepts the whole-collection setting and a Global Catalog material", async () => {
+    const cookie = await registerAndVerify(app, alice);
+    const petg = await storage.createMaterial({ name: "PETG" });
+
+    await request(app).post("/api/user-sharing").set("Cookie", cookie).send({ isPublic: true }).expect(201);
+    await request(app).post("/api/user-sharing").set("Cookie", cookie).send({ materialId: petg.id, isPublic: true }).expect(201);
   });
 });

--- a/tests/server/error-handler.test.ts
+++ b/tests/server/error-handler.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { errorHandler } from "../../server/utils/error-handler";
+
+function appWith(route?: (app: express.Express) => void) {
+  const app = express();
+  app.use(express.json({ limit: "1kb" }));
+  app.post("/echo", (req, res) => res.json(req.body));
+  route?.(app);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("errorHandler", () => {
+  it("answers a malformed JSON body with a fixed 400", async () => {
+    const res = await request(appWith()).post("/echo").set("Content-Type", "application/json").send("{bad json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: "Request body is not valid JSON" });
+  });
+
+  it("answers an oversized body with 413", async () => {
+    const res = await request(appWith()).post("/echo").send({ pad: "x".repeat(2000) });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ message: "Request body is too large" });
+  });
+
+  it("does not echo an internal error's message", async () => {
+    const app = appWith((a) => a.get("/boom", () => { throw new Error("SELECT secret FROM users failed"); }));
+
+    const res = await request(app).get("/boom");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ message: "Internal Server Error" });
+  });
+
+  it("keeps the connection usable after an error", async () => {
+    const app = appWith();
+    await request(app).post("/echo").set("Content-Type", "application/json").send("{bad json").expect(400);
+    const res = await request(app).post("/echo").send({ ok: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/tests/utils/csv-parser.test.ts
+++ b/tests/utils/csv-parser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { escapeCsvField } from "../../server/utils/csv-parser";
+
+describe("escapeCsvField", () => {
+  it("leaves plain text and plain numbers alone", () => {
+    expect(escapeCsvField("Prusament")).toBe("Prusament");
+    expect(escapeCsvField(29.99)).toBe("29.99");
+    expect(escapeCsvField("-5")).toBe("-5");
+    expect(escapeCsvField(null)).toBe("");
+  });
+
+  it("quotes commas, quotes and line breaks", () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvField("two\nlines")).toBe('"two\nlines"');
+    expect(escapeCsvField("cr\rhere")).toBe('"cr\rhere"');
+  });
+
+  // A spool named like a formula would run when the export is opened in a
+  // spreadsheet. The apostrophe makes it text; the quoting keeps the CSV valid.
+  it("neutralises cells a spreadsheet would treat as a formula", () => {
+    expect(escapeCsvField('=HYPERLINK("http://evil/","x")')).toBe(`"'=HYPERLINK(""http://evil/"",""x"")"`);
+    expect(escapeCsvField("+1+1")).toBe("'+1+1");
+    expect(escapeCsvField("-cmd")).toBe("'-cmd");
+    expect(escapeCsvField("@SUM(A1)")).toBe("'@SUM(A1)");
+    expect(escapeCsvField("\tx")).toBe("'\tx");
+  });
+});


### PR DESCRIPTION
## Description

Second of three PRs from the security audit. Stacked on #27 because it reuses the shared limiters introduced there; the diff shown here is only this PR's own commit. Retarget to `main` once #27 is in.

| finding | severity | fix |
| --- | --- | --- |
| Public share endpoint returned whole spool rows: price, purchase date, storage location, custom fields, notification timestamps | medium | Projects to the product fields the page renders (id, name, manufacturer, material, colour, code, diameter, print temp, remaining %). One 404 message for "unknown id" and "shares nothing", so ids cannot be enumerated. Rate-limited. |
| CSV exports carried spreadsheet formulas unneutralised | medium | `escapeCsvField` prefixes cells starting with `= + - @ \t \r` with an apostrophe (plain numbers excepted) and quotes `\r`. |
| Spool writes accepted any type: `status: "bogus"`, `purchaseDate: "yesterday"`, a string for custom fields | low | `filamentWriteSchema` / `filamentPatchSchema` on POST, PATCH and batch. Numbers as strings or numbers, dates as `YYYY-MM-DD`, enums for status and spool type, custom-field values a bounded map of scalars. Imports capped at 2000 rows. |
| Error handler rethrew after responding and echoed body-parser's message | low | `server/utils/error-handler.ts`: fixed message per class, logs the rest, never leaks an internal message. |
| API token accepted in `?token=` | low | Header only. `docs/API.md` updated. |
| Deleting a Global Catalog row checked only the admin's own spools | low | `getFilamentsOfAllUsers()` for global rows, owner's spools for personal rows. |
| Sharing settings inserted `materialId` unvalidated | low | Integer, and must be a material the caller can see. |
| SpoolmanDB sync: no timeout, no size cap, remote shape trusted | low | 20 s `AbortSignal.timeout`, 8 MB cap, zod schema per vendor file; a bad file is skipped with a warning. |
| No limiter on backups, cache refresh, test mail | low | `sensitiveActionLimiter` on all three. |
| Catalog request payload stored unstripped | info | Stored as parsed. |
| Client console logged passwords, SMTP credentials, API tokens, request bodies | low | Removed. |

### A note on the flaky test the helper now explains

#21 made `loginAs` report what came back when a login has no cookie. It fired once during this work, on Postgres:

```
login as alice answered 200 without a session cookie; headers: {"accept-ranges":"bytes","content-length":"6293","content-type":"text/html; charset=utf-8","connection":"close"} body: {}
```

That is a static HTML file of 6293 bytes served with `Accept-Ranges`, on a `POST /api/auth/login` to a fresh supertest server. No Filadex route produces it (`dist/public/index.html` is 2090 bytes), so the response reached the test from some other listener. Not this PR's to solve, but it is the first hard evidence about that family of failures, and worth keeping in mind for #19/#21.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change — deliberate, small: `?token=` is no longer accepted for API tokens (headers still are); the public share endpoint no longer returns purchase and storage fields; spool writes with values outside the schema now answer 400 instead of storing them.

## How Has This Been Tested?

- [x] New: `tests/utils/csv-parser.test.ts`, `tests/server/error-handler.test.ts`, `tests/routes/integrations.test.ts`, `tests/routes/filament-writes.test.ts`; new cases in `public`, `settings`, `users`, `community-filaments`
- [x] `TEST_DIALECT=sqlite npx vitest run` — 452 passed, 1 skipped
- [x] Postgres subset (filament-writes, public, settings, users, integrations, community-filaments) — passes; one run hit the flake above, two reruns clean
- [x] `npm run check`, `npm run lint` — clean
- [x] `npm run build && npm run test:e2e` — 6 passed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
