### PR TITLE
Count only failed attempts against the login limiter

### DIFF
--- a/server/utils/rate-limits.ts
+++ b/server/utils/rate-limits.ts
@@ -15,11 +15,19 @@ export const publicAuthLimiter = rateLimit({
 
 // Anything that verifies a password: login, and change-password, which with a
 // stolen session would otherwise be an unthrottled oracle for the current one.
+//
+// Only failed attempts count. That is what the limiter is for - an attacker
+// guessing passwords produces 401s, and those still consume the budget - while
+// someone who knows their password never spends anyone else's, which matters
+// on a shared address behind NAT or a reverse proxy. It also keeps the browser
+// suite honest: it signs in about fifteen times per run, and counting those
+// successes put it one flaky retry away from locking itself out.
 export const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 15,
   standardHeaders: true,
   legacyHeaders: false,
+  skipSuccessfulRequests: true,
   message: { message: "Too many login attempts, please try again later" },
 });
 


### PR DESCRIPTION
## Description

`main` is red on `d9ba68b`, and this is why.

#32 added six browser specs. Each signs in, so a clean run of the suite now makes **exactly fifteen successful logins** — the login limiter's entire 15-per-15-minutes budget. Any single flaky retry makes sixteen, and the next sign-in is refused. That is what CI hit: `materials-attention` retried, and then `register-language`'s admin sign-in came back `429` and sat on `/login`:

```
Expected pattern: not /\/login/
Received string:  "http://127.0.0.1:5183/login"
```

Nothing was wrong with that login. The suite had locked itself out.

Verified directly against the built server, before any change:

```
16 correct logins in a row:
200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 429
```

## The fix

`skipSuccessfulRequests: true` on the login limiter, so only failed attempts consume the budget.

This is not a loosening dressed up as a fix — it is what the limiter always meant. It exists to slow down password guessing, and guessing produces 401s, which still count. Measured after the change:

| | result |
| --- | --- |
| 20 correct logins | all `200` |
| then 15 wrong passwords | `401` ×15, then `429` |
| then a correct password | `429` |

So brute force is still stopped at fifteen attempts, and an attacker cannot outrun the lockout by interleaving a login they do know. A legitimate user simply no longer spends the budget — which also matters on a shared address, behind NAT or a reverse proxy without `TRUST_PROXY`, where one person signing in normally could previously lock out everyone else.

`change-password` shares this limiter and gets the same treatment: a wrong current password still counts, a successful change does not.

Considered and rejected: raising the limit (moves the cliff, does not remove it) and an environment switch to disable limiters for the test run (ships a production kill switch for brute-force protection — see my review on #33).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Built server probed by hand, before and after — the table above
- [x] `npx playwright test` — 14 passed, run twice back to back
- [x] `TEST_DIALECT=sqlite npx vitest run` — 490 passed, 1 skipped
- [x] `npm run check`, `npm run lint` — clean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
